### PR TITLE
Fixed header and footer links

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -40,12 +40,6 @@
 
 {% block header %}
   {{ header({
-    "transactionalService": {
-        "name": "Prototype kit",
-        "href": "/docs"
-      },
-      "showNav": "false",
-      "showSearch": "false"
     })
   }}
 {% endblock %}

--- a/docs/assets/sass/docs.scss
+++ b/docs/assets/sass/docs.scss
@@ -1,10 +1,9 @@
 // NHS.UK frontend library
 @import 'node_modules/nhsuk-frontend/packages/nhsuk';
 
-// Overrides auto reload div background colour
-#hc_extension_bkgnd {
-  background-color: $color_nhsuk-grey-4 !important;
-}
+// ==========================================================================
+// FRONTEND STYLE ADJUSTMENTS
+// ==========================================================================
 
 // Body background white
 .nhsuk-body-white {
@@ -16,7 +15,25 @@
   background-color: $color_nhsuk-grey-5;
 }
 
-// Button adjustment
+// Header adjustment
+//
+// Fix for service header with a short name
+.nhsuk-header__link--service-short-name {
+  -ms-flex-align: center;
+  align-items: center;
+  display: flex;
+  margin-bottom: 0;
+}
+
+.nhsuk-header__service-name {
+  padding-left: 16px;
+  padding-right: 16px;
+  padding-top: 0;
+}
+
+// Button
+//
+// Tweaked button spacing
 .nhsuk-button {
   margin-top: nhsuk-spacing(2);
 
@@ -25,7 +42,9 @@
   }
 }
 
-// Footer adjustments
+// Footer
+//
+// A modifier to have the footer links in 3 columns
 @include mq($from: desktop) {
   .nhsuk-footer__list--three-columns{
     -webkit-column-count: 3;
@@ -38,7 +57,6 @@
 }
 
 // Panel - confirmation
-
 .nhsuk-panel--confirmation {
   background-color: shade($color_nhsuk-aqua-green, 19%);
   color: $color_nhsuk-white;
@@ -66,7 +84,16 @@
   }
 }
 
-// Code styling
+// ==========================================================================
+// PROTOTYPE SPECIFIC STYLES
+// ==========================================================================
+
+// Overrides auto reload div background colour
+#hc_extension_bkgnd {
+  background-color: $color_nhsuk-grey-4 !important;
+}
+
+// <pre> and <code> tag styles
 .app-pre {
   @include nhsuk-responsive-margin(4, "bottom");
 
@@ -93,8 +120,7 @@ p .app-code {
   border: 1px solid $color_nhsuk-grey-4;
 }
 
-// Installation guide images
-
+// Installation guide screenshots
 .app-img-guide {
   width: 100%;
 }

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -45,35 +45,38 @@
 {% endblock %}
 
 {% block header %}
-  {{ header({
-    "transactionalService": {
-        "name": "Prototype kit",
-        "href": "/docs"
-      },
-      "showNav": "false",
-      "showSearch": "false"
-    })
-  }}
+  <header class="nhsuk-header" role="banner">
+    <div class="nhsuk-width-container nhsuk-header__container">
+      <div class="nhsuk-header__logo">
+        <a class="nhsuk-header__link nhsuk-header__link--service nhsuk-header__link--service-short-name" href="/docs" aria-label="NHS.UK prototype kit home">
+          <svg class="nhsuk-logo nhsuk-logo--white" xmlns="http://www.w3.org/2000/svg" role="presentation" focusable="false" viewBox="0 0 40 16">
+            <path fill="#fff" d="M0 0h40v16H0z"></path>
+            <path fill="#005eb8" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>
+            <image src="https://assets.nhs.uk/images/nhs-logo.png" xlink:href=""></image>
+          </svg>
+          <span class="nhsuk-header__service-name">
+          Prototype kit
+          </span>
+        </a>
+      </div>
+    </div>
+  </header>
 {% endblock %}
 
 {% block footer %}
   {{ footer({
     "links": [
       {
-        "URL": "/docs/install",
-        "label": "Download and install"
-      },
-      {
-        "URL": "/docs/how-tos",
-        "label": "How-tos"
-      },
-      {
-        "URL": "/docs/templates",
-        "label": "Page templates"
+        "URL": "/docs",
+        "label": "Home"
       },
       {
         "URL": "/docs/about",
         "label": "About and support"
+      },
+      {
+        "URL": "https://github.com/nhsuk/nhsuk-prototype-kit",
+        "label": "NHS.UK prototype kit - GitHub"
       }
     ]
   })}}


### PR DESCRIPTION
The docs now use the Header with a service instead of a transactional header.
Updated the footer links to include a Home and GitHub.