### PR TITLE
Build stage `postinstall` instead of `prestart`

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "build": "gulp build",
-    "prestart": "npm run build",
+    "postinstall": "npm run build",
     "start": "node app.js",
     "test": "",
     "prewatch": "gulp build",


### PR DESCRIPTION
When deploying this project, the build should be a one-off task that is run after installing dependencies (`npm install`) - it doesn't need to be run as part of the server startup (`npm start`).

This change will support our deployment to azure - but will still work on heroku.

N.B: Running `npm start` in local development will no longer re-build static assets. `npm run watch` should always be used for local dev.