### PR TITLE
Updated Slack URLs

### DIFF
--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -35,7 +35,7 @@
       <p>The prototype kit is always evolving as we learn more. Help us to improve and grow it:</p>
 
       <ul>
-        <li><a href="https://nhsuk.slack.com/messages/standards" rel="nofollow">get in touch on the NHS.UK #standards Slack channel</a></li>
+        <li><a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">get in touch on the NHS.UK #standards Slack channel</a></li>
         <li><a href="https://github.com/nhsuk/nhsuk-prototype-kit/issues">create a GitHub issue</a></li>
       </ul>
 

--- a/docs/views/install/index.html
+++ b/docs/views/install/index.html
@@ -22,7 +22,9 @@
 
       <h2>Install guide</h2>
 
-      <p>Install the kit in 10 steps. You don’t need any technical knowledge to follow along.</p>
+      <p>Install the kit in 10 steps.</p> 
+      
+      <p>You don’t need any technical knowledge to follow along.</p>
 
       <p>Installation takes up to 20 minutes depending on how much you need to install.</p>
 

--- a/docs/views/install/simple.html
+++ b/docs/views/install/simple.html
@@ -28,7 +28,7 @@
 
       <p class="nhsuk-body-l">These instructions explain how to install and begin to use the kit in 10 steps. You don’t need any technical knowledge to follow along.</p>
       
-      <p>If you have any problems, ask a developer on your team (if you have one), <a href="mailto:service-manual@nhs.net?subject=NHS.UK prototype kit - Installation">email us</a> or get in touch on the <a href="https://nhsuk.slack.com/messages/prototype-kit" rel="nofollow">NHS.UK #prototype-kit Slack channel</a>.</p>
+      <p>If you have any problems, ask a developer on your team (if you have one), <a href="mailto:service-manual@nhs.net?subject=NHS.UK prototype kit - Installation">email us</a> or get in touch on the <a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">NHS.UK #prototype-kit Slack channel</a>.</p>
       
       <p>Installation takes up to 20 minutes depending on how much you need to install.</p>
       


### PR DESCRIPTION
Change the Slack URLs to the prototype-kit channel on the service manual workspace.