### PR TITLE
update main element ID from main-content to maincontent

### DIFF
--- a/docs/views/examples/passing-data/passing-data-confirmation.html
+++ b/docs/views/examples/passing-data/passing-data-confirmation.html
@@ -19,7 +19,7 @@
 
 {% block main %}
   <div class="nhsuk-width-container">
-    <main class="nhsuk-main-wrapper nhsuk-main-wrapper--s" id="main-content" role="main">
+    <main class="nhsuk-main-wrapper nhsuk-main-wrapper--s" id="maincontent" role="main">
 
     {% block content %}
       <div class="nhsuk-grid-row">

--- a/docs/views/layouts/template.html
+++ b/docs/views/layouts/template.html
@@ -36,7 +36,7 @@
 
       {% block skipLink %}
         {{ skipLink({
-          href: '#main-content',
+          href: '#maincontent',
           text: 'Skip to main content'
         }) }}
       {% endblock %}
@@ -49,7 +49,7 @@
 
       {% block main %}
         <div class="nhsuk-width-container">
-          <main class="nhsuk-main-wrapper {{ mainClasses }}" id="main-content" role="main">
+          <main class="nhsuk-main-wrapper {{ mainClasses }}" id="maincontent" role="main">
             {% block content %}{% endblock %}
           </main>
         </div>


### PR DESCRIPTION
Inline with the guidance of the NHS digital service manual, the
ID of the main element should be a unique ID of maincontent (rather
than main-content).
https://beta.nhs.uk/service-manual/styles-components-patterns/skip-link