### PR TITLE
update links to the latest service manual URL

### DIFF
--- a/app/views/index.html
+++ b/app/views/index.html
@@ -20,7 +20,7 @@
 {% endblock %}
 
 <!-- Your page content goes inside the content block -->
-<!-- More info and code for the page layout can be found at https://beta.nhs.uk/service-manual/styles-components-patterns/layout -->
+<!-- More info and code for the page layout can be found at https://service-manual.nhs.uk/design-system/styles/layout -->
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
@@ -32,7 +32,7 @@
       </h1>
 
       <!-- Add your content here -->
-      <!-- Styles and components can be found at https://beta.nhs.uk/service-manual/styles-components-patterns -->
+      <!-- Styles and components can be found at https://service-manual.nhs.uk/design-system -->
 
       <p class="nhsuk-lede-text">
         This kit lets you rapidly create HTML prototypes of NHS services.
@@ -67,7 +67,7 @@
           Get started with <a href="/docs">how to guides and page templates</a>
         </li>
         <li>
-          Copy and paste styles and components from the <a href="https://beta.nhs.uk/service-manual/styles-components-patterns">NHS digital service manual</a>
+          Copy and paste styles and components from the <a href="https://service-manual.nhs.uk/design-system">NHS digital service manual</a>
         </li>
       </ul>
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -18,7 +18,7 @@
 {% endblock %}
 
 <!-- Header goes inside the header block -->
-<!-- More info and code for the header can be found at https://beta.nhs.uk/service-manual/styles-components-patterns/header -->
+<!-- More info and code for the header can be found at https://service-manual.nhs.uk/design-system/components/header -->
 {% block header %}
   {{ header({
     "service": {
@@ -32,7 +32,7 @@
 {% endblock %}
 
 <!-- Footer goes inside the footer block -->
-<!-- More info and code for the footer can be found at https://beta.nhs.uk/service-manual/styles-components-patterns/footer -->
+<!-- More info and code for the footer can be found at https://service-manual.nhs.uk/design-system/components/footer -->
 {% block footer %}
   {{ footer({
     "links": [

--- a/app/views/page-example.html
+++ b/app/views/page-example.html
@@ -12,7 +12,7 @@
 {% endblock %}
 
 <!-- Breadcrumb goes inside the beforeContent block -->
-<!-- More info and code for the breadcrumb can be found at https://beta.nhs.uk/service-manual/styles-components-patterns/breadcrumbs -->
+<!-- More info and code for the breadcrumb can be found at https://service-manual.nhs.uk/design-system/components/breadcrumbs -->
 {% block beforeContent %}
   {{ breadcrumb({
     href: "/",
@@ -21,7 +21,7 @@
 {% endblock %}
 
 <!-- Your page content goes inside the content block -->
-<!-- More info and code for the page layout can be found at https://beta.nhs.uk/service-manual/styles-components-patterns/layout -->
+<!-- More info and code for the page layout can be found at https://service-manual.nhs.uk/design-system/styles/layout -->
 {% block content %}
 
   <div class="nhsuk-grid-row">
@@ -34,14 +34,14 @@
       </h1>
 
       <!-- Add your content here -->
-      <!-- Styles and components can be found at https://beta.nhs.uk/service-manual/styles-components-patterns -->
+      <!-- Styles and components can be found at https://service-manual.nhs.uk/design-system -->
       <p class="nhsuk-lede-text">
         This page example includes a selection of styles and components available to the prototype kit.
       </p>
       
       <p>
         For more styles, code snippets and guidance on components visit the
-        <a href="https://beta.nhs.uk/service-manual/styles-components-patterns">NHS digital service manual</a>.
+        <a href="https://service-manual.nhs.uk/design-system">NHS digital service manual</a>.
       </p>
 
       <figure class="nhsuk-image">

--- a/docs/views/how-tos/components.html
+++ b/docs/views/how-tos/components.html
@@ -25,7 +25,7 @@
 
       <p>You can copy the HTML or Nunjucks code from each of the components pages on the components section of the service manual</a>.</p>
 
-      <p>Explore the <a href="https://beta.nhs.uk/service-manual/styles-components-patterns">NHS.UK digital service manual</a> for code snippets and guidance on how to use components.</p>
+      <p>Explore the <a href="https://service-manual.nhs.uk/design-system">NHS.UK digital service manual</a> for code snippets and guidance on how to use components.</p>
 
       {% include "how-tos/includes/back-button.html" %}
 

--- a/docs/views/index.html
+++ b/docs/views/index.html
@@ -41,7 +41,7 @@
       <hr>
 
       <div class="nhsuk-u-reading-width">
-        <p class="nhsuk-u-margin-bottom-0">Visit the <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a> for guidance and examples.</p>
+        <p class="nhsuk-u-margin-bottom-0">Visit the <a href="https://service-manual.nhs.uk">NHS digital service manual</a> for guidance and examples.</p>
       </div>
 
     </div>

--- a/docs/views/templates/content-page.html
+++ b/docs/views/templates/content-page.html
@@ -22,7 +22,7 @@
 
       <p class="nhsuk-lede-text">
         Visit the 
-          <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a> 
+          <a href="https://service-manual.nhs.uk">NHS digital service manual</a> 
         for guidance and examples.
       </p>
 

--- a/docs/views/templates/mini-hub/index.html
+++ b/docs/views/templates/mini-hub/index.html
@@ -46,7 +46,7 @@
 
       <p>
         [Visit the
-        <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a>
+        <a href="https://service-manual.nhs.uk">NHS digital service manual</a>
         for guidance and examples.]
       </p>
 

--- a/docs/views/templates/mini-hub/page-2.html
+++ b/docs/views/templates/mini-hub/page-2.html
@@ -52,7 +52,7 @@
 
       <p>
         [Visit the
-        <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a>
+        <a href="https://service-manual.nhs.uk">NHS digital service manual</a>
         for guidance and examples.]
       </p>
 

--- a/docs/views/templates/mini-hub/page-3.html
+++ b/docs/views/templates/mini-hub/page-3.html
@@ -52,7 +52,7 @@
 
       <p>
         [Visit the
-        <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a>
+        <a href="https://service-manual.nhs.uk">NHS digital service manual</a>
         for guidance and examples.]
       </p>
 

--- a/docs/views/templates/question-page.html
+++ b/docs/views/templates/question-page.html
@@ -20,7 +20,7 @@
 
         <p>
           [Visit the 
-            <a href="https://beta.nhs.uk/service-manual/">NHS digital service manual</a> 
+            <a href="https://service-manual.nhs.uk">NHS digital service manual</a> 
           for guidance and examples.]
         </p>
 


### PR DESCRIPTION
## Description

The NHS digital service manual recently went from beta to live. This change is up date all the links to the service manual in the documentation.