### PR TITLE
Enable adding of custom per template styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK prototype kit Changelog
 
-## Latest
+## 4.6.0 - 16 August 2021
 
 :new: **New features**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK prototype kit Changelog
 
+## Latest
+
+:new: **New features**
+
+- Allow adding of custom styles on a per template basis with `customStyles` template block.
+
 ## 4.5.1 - 29 July 2021
 
 :new: **New features**

--- a/docs/views/how-tos/adding-assets.html
+++ b/docs/views/how-tos/adding-assets.html
@@ -27,9 +27,21 @@
       
       <p>CSS lets you change how web pages look, for example text sizes, colours or spacing.</p>
       
-      <p>To add styles use:</p>
+      <p>To add universal styles use:</p>
       
-      <pre class="app-pre"><code class="app-code">/app/assets/sass/main.scss</code></pre><p>Do not edit the file <code class="app-code">/public/styles/main.css</code> because it’s deleted and rebuilt every time you make a change to your prototype.</p>
+      <pre class="app-pre"><code class="app-code">/app/assets/sass/main.scss</code></pre>
+
+      <p>Styles can also be added to individual templates via the "customStyles" template block:</p>
+
+      <pre class="app-pre">
+        <code class="app-code">{{'{% block customStyles %}'}}
+          &lt;STYLE type=&quot;text/css&quot;&gt;
+            body { background-color: pink; }
+          &lt;/STYLE&gt;
+        {{'{% endblock %}'}}</code></pre>
+        
+      
+      <p>Do not edit the file <code class="app-code">/public/styles/main.css</code> because it’s deleted and rebuilt every time you make a change to your prototype.</p>
       
       <p>The prototype kit uses <a href="https://sass-lang.com/guide">Sass</a>, which adds extra features to CSS.</p>
       

--- a/docs/views/template.html
+++ b/docs/views/template.html
@@ -55,6 +55,9 @@
       <link href="/css/main.css" rel="stylesheet">
     {% endblock %}
 
+    {% block customStyles %}
+    {% endblock %}
+
     <script src="/nhsuk-frontend/nhsuk.min.js" defer></script>
 
     {% block headIcons %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-prototype-kit",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-prototype-kit",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "Rapidly create HTML prototypes of NHS websites and services.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Description

Solves #188 by allowing the addition of per template styles.

Custom styles can now be added to the top of templates like this:
```
{% block customStyles %}
  <STYLE type="text/css">
    body { background-color: pink; }
  </STYLE>
{% endblock %}
```

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
