### PR TITLE
Correct links on about page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK prototype kit Changelog
 
+## 4.6.2 - 24 August 2021
+
+:wrench: **Fixes**
+
+- Correct slack channel links on the `About` page.
+
 ## 4.6.1 - 18 August 2021
 
 :wrench: **Fixes**

--- a/docs/views/about.html
+++ b/docs/views/about.html
@@ -26,7 +26,7 @@
 
       <ul>
         <li><a href="mailto:service-manual@nhs.net?subject=NHS.UK prototype kit - About">email us</a></li>
-        <li><a href="https://nhsuk.slack.com/messages/standards" rel="nofollow">get in touch on the NHS.UK #standards Slack channel</a></li>
+        <li><a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">get in touch on the NHS.UK #prototype-kit Slack channel</a></li>
         <li><a href="https://github.com/nhsuk/nhsuk-prototype-kit/issues">view known issues on GitHub</a></li>
       </ul>
       
@@ -35,7 +35,7 @@
       <p>The prototype kit is always evolving as we learn more. Help us to improve and grow it:</p>
 
       <ul>
-        <li><a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">get in touch on the NHS.UK #standards Slack channel</a></li>
+        <li><a href="https://nhs-service-manual.slack.com/messages/CFYL2GDGW" rel="nofollow">get in touch on the NHS.UK #prototype-kit Slack channel</a></li>
         <li><a href="https://github.com/nhsuk/nhsuk-prototype-kit/issues">create a GitHub issue</a></li>
       </ul>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-prototype-kit",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-prototype-kit",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Rapidly create HTML prototypes of NHS websites and services.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Description

Correct slack channel links on the about and support page.
Fixes #185.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
