### PR TITLE
remove release action for uploading versioned assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,15 +39,3 @@ jobs:
           release_name:  ${{ github.ref }}
           draft: false
           prerelease: false
-
-      - name: Upload release asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./dist/nhsuk-prototype-kit-${{ steps.get_version.outputs.VERSION }}.zip
-          asset_name: nhsuk-prototype-kit-${{ steps.get_version.outputs.VERSION }}.zip
-          asset_content_type: application/zip
-          


### PR DESCRIPTION
## Description

We can remove the action to upload the `zip` file with the version number in the name, as there is no compiled `zip` folder to upload from the project and we are just going to use the default `zip` file that gets uploaded during a release. eg. https://github.com/nhsuk/nhsuk-prototype-kit/archive/refs/tags/v4.6.3.zip
