### PR TITLE
changed download link to version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # NHS.UK prototype kit Changelog
 
-## 4.7.1 - TBC
+## 4.7.1 - 12 October 2021
 
 :wrench: **Fixes**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NHS.UK prototype kit Changelog
 
+## 4.7.1 - TBC
+
+:wrench: **Fixes**
+
+- Update download link for the prototype-kit to use the latest release instead of the master branch
+
+
 ## 4.7.0 - 22 September 2021
 
 :new: **New features**

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -1,5 +1,6 @@
 // External dependencies
 const express = require('express');
+const packageJson = require('../package.json');
 
 const router = express.Router();
 
@@ -33,12 +34,12 @@ router.post('/install/mac', (req, res) => {
   }
 });
 
-router.get('/download', function (req, res) {
-  const version = require('../package.json').version
+router.get('/download', (req, res) => {
+  const { version } = packageJson;
   res.redirect(
-    `https://github.com/nhsuk/nhsuk-prototype-kit/archive/refs/tags/v${version}.zip`
-  )
-})
+    `https://github.com/nhsuk/nhsuk-prototype-kit/archive/refs/tags/v${version}.zip`,
+  );
+});
 
 // Branching example
 router.post('/examples/branching/answer', (req, res) => {

--- a/docs/documentation_routes.js
+++ b/docs/documentation_routes.js
@@ -33,6 +33,13 @@ router.post('/install/mac', (req, res) => {
   }
 });
 
+router.get('/download', function (req, res) {
+  const version = require('../package.json').version
+  res.redirect(
+    `https://github.com/nhsuk/nhsuk-prototype-kit/archive/refs/tags/v${version}.zip`
+  )
+})
+
 // Branching example
 router.post('/examples/branching/answer', (req, res) => {
   // Make a variable and give it the value from 'know-nhs-number'

--- a/docs/views/install/download-zip.html
+++ b/docs/views/install/download-zip.html
@@ -28,7 +28,7 @@
 
       <h2>Zip file</h2>
 
-      <p>The simplest way to get the kit is to <a href="https://github.com/nhsuk/nhsuk-prototype-kit/archive/master.zip" data-link="download">download it as a zip</a>.</p>
+      <p>The simplest way to get the kit is to <a href="/docs/download" data-link="download">download it as a zip</a>.</p>
 
       <h2>GitHub</h2>
 

--- a/docs/views/install/download.html
+++ b/docs/views/install/download.html
@@ -34,7 +34,7 @@
 
       <h2>2. Download the kit</h2>
 
-      <p>The simplest way to get the kit is to <a href="https://github.com/nhsuk/nhsuk-prototype-kit/archive/master.zip" data-link="download">download it as a zip</a>.</p>
+      <p>The simplest way to get the kit is to <a href="/docs/download" data-link="download">download it as a zip</a>.</p>
     
       <p>You'll use a new copy of the kit for each new prototype you make. That way your prototypes don’t interfere with each other.</p>
 

--- a/docs/views/install/download.html
+++ b/docs/views/install/download.html
@@ -40,7 +40,7 @@
 
       <h2>3. Unzip the kit</h2>
 
-      <p>Unzip the kit you downloaded - you should end up with a folder called <strong>nhsuk-prototype-kit-master</strong>.</p>
+      <p>Unzip the kit you downloaded - you should end up with a folder called <strong>nhsuk-prototype-kit</strong> followed by the version number.</p>
 
       {% block branchingContentTwo %}
       {% endblock %}

--- a/docs/views/install/where-to-keep.html
+++ b/docs/views/install/where-to-keep.html
@@ -36,7 +36,7 @@
 
       <h3>1. Unzip the kit</h3>
 
-      <p>Unzip the kit you downloaded - you should end up with a folder called <strong>nhsuk-prototype-kit-master</strong>.</p>
+      <p>Unzip the kit you downloaded - you should end up with a folder called <strong>nhsuk-prototype-kit</strong> followed by the version number.</p>
 
       <h3>2. Rename the folder</h3>
 

--- a/docs/views/install/windows/download.html
+++ b/docs/views/install/windows/download.html
@@ -9,7 +9,7 @@
 {% block branchingContentTwo %}
   <img class="app-img-guide nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-6" alt="Screenshot of the downloaded zip file" src="/images/windows/download-unzip.png" />
 
-  <p>Open that folder by double clicking on it. You should then see another folder named <strong>nhsuk-prototype-kit-master</strong>.</p>
+  <p>Open that folder by double clicking on it. You should then see another folder named <strong>nhsuk-prototype-kit</strong> followed by the version number.</p>
 
   <img class="app-img-guide nhsuk-u-margin-top-3 nhsuk-u-margin-bottom-6" alt="Screenshot of the downloaded zip file" src="/images/windows/download-unzip-open.png" />
 {% endblock %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-prototype-kit",
-  "version": "4.6.4",
+  "version": "4.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nhsuk-prototype-kit",
-  "version": "4.6.4",
+  "version": "4.7.1",
   "description": "Rapidly create HTML prototypes of NHS websites and services.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Description
changed the download link for the prototype kit to pull the latest version instead of master. this will prevent any issues with users kits that may occur because of unreleased code on master
## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
