### PR TITLE
Add new page on publishing prototype online

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :pencil2: **Content**
 
 - Add new 'Publish your prototype online' guidance
+- Replace Atom with Visual Studio Code on HTML text editor page
 
 ## 4.8.5 - 12 December 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK prototype kit Changelog
 
+## 4.8.6 - TBC January 2023
+
+:pencil2: **Content**
+
+- Add new 'Publish your prototype online' guidance
+
 ## 4.8.5 - 12 December 2022
 
 :wrench: Fixes

--- a/docs/views/how-tos/index.html
+++ b/docs/views/how-tos/index.html
@@ -39,6 +39,7 @@
 
       <ul class="nhsuk-list">
         <li><a href="/docs/how-tos/git">Setting up Git</a></li>
+        <li><a href="/docs/how-tos/publish-your-prototype-online">Publish your prototype online</a></li>
       </ul>
 
       <h2>Updating the kit</h2>

--- a/docs/views/how-tos/publish-your-prototype-online.html
+++ b/docs/views/how-tos/publish-your-prototype-online.html
@@ -1,0 +1,43 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  Publish your prototype online - NHS.UK prototype kit
+{% endblock %}
+
+{% block beforeContent %}
+  {% include "how-tos/includes/breadcrumb.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="nhsuk-grid-row">
+
+    <div class="nhsuk-grid-column-two-thirds">
+
+      <h1>Publish your prototype online</h1>
+      <p>Publishing your prototype online means you can:</p>
+      <ul>
+        <li>share it with others, such as colleagues</li>
+        <li>test it with users</li>
+      </ul>
+      <p>You'll need a hosting service to publish prototypes online.</p>
+      
+      <h2>Hosting services</h2>
+      <p>The NHS.UK prototype kit runs on any hosting service that supports Node.js.</p>
+      <p>Your organisation may already use a hosting service for the prototype kit. Check with your digital team about which platform to use.</p>
+      <p>For example:</p>
+      <ul>
+      <li>Heroku (requires payment) – see <a href="https://devcenter.heroku.com/articles/github-integration">GitHub integration on Heroku website</a></li>
+      <li>Railway – see <a href="https://railway.app/new/github">Deploy repository on Railway website</a></li>
+      </ul>
+      <p>Some hosting services may automatically update your prototype every time you merge new changes in the connected GitHub repository. If it doesn't automatically update your prototype, you will need to do this manually.</p>
+      
+      <h2>Setting a password</h2>
+      <p>When running the prototype kit online, you must set a username and password. This is to stop anyone accidentally finding your prototype and mistaking it for a real service.</p>
+      <p>To set a password, check your hosting services documentation on how to set "environment variables". (It may have a slightly different name like "config vars" or "variables".)</p>
+
+      {% include "how-tos/includes/back-button.html" %}
+
+    </div>
+
+  </div>
+{% endblock %}

--- a/docs/views/install/text-editor.html
+++ b/docs/views/install/text-editor.html
@@ -27,13 +27,13 @@
         HTML text editor
       </h1>
 
-      <p class="nhsuk-lede-text">You’ll need a HTML text editor to edit and make changes to your prototype.</p>
+      <p class="nhsuk-lede-text">You'll need an HTML text editor to edit and make changes to your prototype.</p>
       
-      <p>Any HTML text editor will do, but we recommend Atom - which is free and has lots of useful features.</p>
+      <p>Any HTML text editor will do, but we recommend Visual Studio Code which is free and has lots of useful features.</p>
 
-      <p><a href="https://atom.io/" target="_blank">Download Atom (opens in new window)</a></p>
+      <p><a href="https://code.visualstudio.com/Download" target="_blank">Download Visual Studio Code (opens in new window)</a></p>
 
-      <p>Once you have a HTML text editor installed, return to this guide.</p>
+      <p>Once you have an HTML text editor installed, return to this guide.</p>
 
       {% block pagination %}
       {% endblock %}


### PR DESCRIPTION
## Description
Add new guidance on deploying prototype online, to replace old Heroku guidance

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
