### PR TITLE
Add aria-label to covid-hub navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS.UK prototype kit Changelog
 
+## TBC
+
+:wrench: Fixes
+
+- Add aria-label to coronavirus hub page navigation links
+
 ## 4.9.0 - 1 June 2023
 
 :pencil2: **Content**

--- a/docs/views/templates/nhsuk-coronavirus-hub.html
+++ b/docs/views/templates/nhsuk-coronavirus-hub.html
@@ -343,7 +343,7 @@
         <div class="beta-hub-related-links-title">
           <h2 class="nhsuk-heading-s">NHS COVID-19 test and trace app</h2>
         </div>
-        <nav role="navigation">
+        <nav role="navigation" aria-label="NHS COVID-19 test and trace app">
           <ul class="beta-hub-related-links">
             <li class="beta-hub-related-links__list-item">
               <a href="">
@@ -361,7 +361,7 @@
         <div class="beta-hub-related-links-title">
           <h2 class="nhsuk-heading-s">National restrictions and government advice</h2>
         </div>
-        <nav role="navigation">
+        <nav role="navigation" aria-label="National restrictions and government advice">
           <ul class="beta-hub-related-links">
             <li class="beta-hub-related-links__list-item">
               <a href="">
@@ -385,7 +385,7 @@
         <div class="beta-hub-related-links-title">
           <h2 class="nhsuk-heading-s">Work and financial support</h2>
         </div>
-        <nav role="navigation">
+        <nav role="navigation" aria-label="Work and financial support">
           <ul class="beta-hub-related-links">
             <li class="beta-hub-related-links__list-item">
               <a href="">
@@ -409,7 +409,7 @@
         <div class="beta-hub-related-links-title">
           <h2 class="nhsuk-heading-s">Advice for travellers</h2>
         </div>
-        <nav role="navigation">
+        <nav role="navigation" aria-label="Advice for travellers">
           <ul class="beta-hub-related-links">
             <li class="beta-hub-related-links__list-item">
               <a href="">
@@ -433,7 +433,7 @@
         <div class="beta-hub-related-links-title">
           <h2 class="nhsuk-heading-s">Information for health professionals</h2>
         </div>
-        <nav role="navigation">
+        <nav role="navigation" aria-label="Information for health professionals">
           <ul class="beta-hub-related-links">
             <li class="beta-hub-related-links__list-item">
               <a href="">
@@ -451,7 +451,7 @@
         <div class="beta-hub-related-links-title">
           <h2 class="nhsuk-heading-s">Advice in other parts of the UK</h2>
         </div>
-        <nav role="navigation">
+        <nav role="navigation" aria-label="Advice in other parts of the UK">
           <ul class="beta-hub-related-links">
             <li class="beta-hub-related-links__list-item">
               <a href="">


### PR DESCRIPTION
## Description
Add aria-label to covid-hub navigation on SonarCloud recommendation. [TM-2949](https://nhsd-jira.digital.nhs.uk/browse/TM-2949)
## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
