### PR TITLE
Remove unused imports from utils.test.js

### DIFF
--- a/tests/lib/utils.test.js
+++ b/tests/lib/utils.test.js
@@ -1,5 +1,4 @@
-import utils from 'gulp-clean/utils';
-import { addNunjucksFilters, renderPath, matchRoutes, addCheckedFunction, autoStoreData } from '../../lib/utils';
+import { addNunjucksFilters, matchRoutes, autoStoreData } from '../../lib/utils';
 
 const coreFilters = require('../../lib/core_filters');
 jest.mock('../../lib/core_filters');


### PR DESCRIPTION
## Description
Remove unused imports from utils.test.js on SonarCloud recommendation.  [TM29-57](https://nhsd-jira.digital.nhs.uk/browse/TM-2957)

## Checklist

- [X] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry (N/A)
