### PR TITLE
Add aria-label to mental health page related information navigation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: Fixes
 
 - Add aria-label to coronavirus hub page navigation links
+- Add aria-label to mental health page navigation links
 
 ## 4.9.0 - 1 June 2023
 

--- a/docs/views/templates/nhsuk-mentalhealth.html
+++ b/docs/views/templates/nhsuk-mentalhealth.html
@@ -332,7 +332,7 @@
         <div class="beta-hub-related-links-title">
           <h2 class="nhsuk-heading-s">Related information</h2>
         </div>
-        <nav role="navigation">
+        <nav role="navigation" aria-label="Related information">
           <ul class="beta-hub-related-links">
             <li class="beta-hub-related-links__list-item">
               <a href="">Every Mind Matters</a>


### PR DESCRIPTION
## Description
Add aria-label to mental health page related information navigation links. [TM-2965](https://nhsd-jira.digital.nhs.uk/browse/TM-2965)

## Checklist

- [X] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [X] CHANGELOG entry
