### PR TITLE
Include start script in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ You must protect user privacy at all times, even when using prototypes. Prototyp
 - <a href="http://nhsuk-prototype-kit.azurewebsites.net/docs/install/simple">Install guide (non technical)</a>
 - <a href="http://nhsuk-prototype-kit.azurewebsites.net/docs/install/advanced">Developer friendly install guide (technical)</a>
 
+### Running the kit
+
+Start the kit with `npm run watch`
+
 ## Contribute
 
 If you want to contribute to the NHS.UK prototype kit, by reporting bugs, fixing bugs, suggesting new features or writing documentation, then read our [contributing guidelines](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You must protect user privacy at all times, even when using prototypes. Prototyp
 
 ### Running the kit
 
-Start the kit with `npm run watch`
+Start the kit with `npm run watch`.
 
 ## Contribute
 


### PR DESCRIPTION
## Description
I stumbled when first running this because I assumed it worked like the GOV.UK Prototype kit. I know the start script is mentioned in the install guides, but I've seen that many other repos tend to mention it on the main root readme.