### PR TITLE
Disable Nunjucks caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NHS.UK prototype kit Changelog
 
+## Unreleased
+
+- Disable nunjucks caching so changes to templates show immediately
+
 ## 4.10.0 - 22 February 2024
 
 :wrench: Fixes

--- a/app.js
+++ b/app.js
@@ -51,6 +51,7 @@ const appViews = [
 
 const nunjucksConfig = {
   autoescape: true,
+  noCache: true,
 };
 
 nunjucksConfig.express = app;


### PR DESCRIPTION
## Description

I've been seeing weird issues where I would update a template but the rendered page remained the same until a restart - tracked down to caching being enabled in the app. The [GOV.UK prototype kit disables it](https://github.com/alphagov/govuk-prototype-kit/blob/main/server.js#L85C3-L85C17), and we should too.

## Checklist

- [x] CHANGELOG entry
