### PR TITLE
Remove unnecessary console.log

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -219,7 +219,6 @@ exports.matchMdRoutes = function (req, res) {
 const storeData = function (input, data) {
   const sessionData = data;
   Object.keys(input).forEach((i) => {
-    console.log(i);
     // any input where the name starts with _ is ignored
     if (i.startsWith('_')) {
       return;


### PR DESCRIPTION
Currently all the session data keys are logged to the console on every page load. This removes that, as it’s unnecessary and confusing.

Previously suggested in #224