### PR TITLE
Ignore eslint warnings

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,7 +102,7 @@ if (useAutoStoreData === 'true') {
 function checkFiles() {
   const nodeModulesExists = fs.existsSync(path.join(__dirname, '/node_modules'));
   if (!nodeModulesExists) {
-    console.error('ERROR: Node module folder missing. Try running `npm install`');
+    console.error('ERROR: Node module folder missing. Try running `npm install`'); // eslint-disable-line no-console
     process.exit(0);
   }
 
@@ -123,7 +123,7 @@ const sessionDataDefaultsFile = path.join(dataDirectory, '/session-data-defaults
 const sessionDataDefaultsFileExists = fs.existsSync(sessionDataDefaultsFile);
 
 if (!sessionDataDefaultsFileExists) {
-  console.log('Creating session data defaults file');
+  console.log('Creating session data defaults file'); // eslint-disable-line no-console
   if (!fs.existsSync(dataDirectory)) {
     fs.mkdirSync(dataDirectory);
   }
@@ -220,14 +220,14 @@ app.post(/^\/([^.]+)$/, (req, res) => {
 
 // Catch 404 and forward to error handler
 app.use((req, res, next) => {
-  const err = new Error(`Page not found: ${req.path}`);
+  const err = new Error(`Page not found: ${req.path}`); // eslint-disable-line no-console
   err.status = 404;
   next(err);
 });
 
 // Display error
 app.use((err, req, res) => {
-  console.error(err.message);
+  console.error(err.message); // eslint-disable-line no-console
   res.status(err.status || 500);
   res.send(err.message);
 });

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,4 +1,4 @@
-module.exports = function (env) { /* eslint-disable-line no-unused-vars */
+module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
   /**
    * Instantiate object used to store the methods registered as a
    * 'filter' (of the same name) within nunjucks. You can override

--- a/lib/core_filters.js
+++ b/lib/core_filters.js
@@ -1,4 +1,4 @@
-module.exports = function (env) {
+module.exports = function (env) { /* eslint-disable-line func-names */
   // If you need access to an internal nunjucks filter you can use env
   // see the example below for 'safe' which is used in 'filters.log'
   const nunjucksSafe = env.getFilter('safe');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@ const path = require('path');
 const coreFilters = require('./core_filters');
 const customFilters = require('../app/filters');
 
-exports.addNunjucksFilters = function (env) {
+exports.addNunjucksFilters = function (env) { /* eslint-disable-line func-names */
   const filters = Object.assign(coreFilters(env), customFilters(env));
   Object.keys(filters).forEach((filterName) => {
     env.addFilter(filterName, filters[filterName]);
@@ -15,8 +15,8 @@ exports.addNunjucksFilters = function (env) {
 };
 
 // Add Nunjucks function called 'checked' to populate radios and checkboxes
-exports.addCheckedFunction = function (env) {
-  env.addGlobal('checked', function (name, value) {
+exports.addCheckedFunction = function (env) { /* eslint-disable-line func-names */
+  env.addGlobal('checked', function (name, value) { /* eslint-disable-line func-names */
     // Check data exists
     if (this.ctx.data === undefined) {
       return '';
@@ -186,7 +186,7 @@ function renderPath(routePath, res, next) {
   });
 }
 
-exports.matchRoutes = function (req, res, next) {
+exports.matchRoutes = function (req, res, next) { /* eslint-disable-line func-names */
   let routePath = req.path;
 
   // Remove the first slash, render won't work with it
@@ -216,7 +216,7 @@ exports.matchMdRoutes = function (req, res) {
 
 // Store data from POST body or GET query in session
 
-const storeData = function (input, data) {
+const storeData = function (input, data) { /* eslint-disable-line func-names */
   const sessionData = data;
   Object.keys(input).forEach((i) => {
     // any input where the name starts with _ is ignored
@@ -262,11 +262,11 @@ try {
   /* eslint-disable-next-line */
   sessionDataDefaults = require(sessionDataDefaultsFile);
 } catch (e) {
-  console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?');
+  console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?'); // eslint-disable-line no-console
 }
 
 // Middleware - store any data sent in session, and pass it to all views
-exports.autoStoreData = function (req, res, next) {
+exports.autoStoreData = function (req, res, next) { /* eslint-disable-line func-names */
   if (!req.session.data) {
     req.session.data = {};
   }

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -14,7 +14,7 @@
 // External dependencies
 const basicAuth = require('basic-auth');
 
-module.exports = function (req, res, next) { /* eslint-disable-line consistent-return */
+module.exports = function (req, res, next) { /* eslint-disable-line func-names,consistent-return */
   // Set configuration variables
   const env = (process.env.NODE_ENV || 'development').toLowerCase();
   const username = process.env.PROTOTYPE_USERNAME;

--- a/middleware/auto-routing.js
+++ b/middleware/auto-routing.js
@@ -32,7 +32,7 @@ function renderPath(path, res, next) {
   });
 }
 
-exports.matchRoutes = function (req, res, next) {
+exports.matchRoutes = function (req, res, next) { /* eslint-disable-line func-names */
   let { path } = req;
 
   path = path.substr(1); // [6] //


### PR DESCRIPTION
This ignores some existing eslint (javascript style) warnings currently present in `main`:

* Unexpected unnamed function (x10)
* Unexpected console statement  (x4)

This gets us to zero warnings, so that we could enable it as a required check before merging.

Thanks to @mcheung-nhs for originally suggesting in this #224.