### PR TITLE
Stop watching html files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Disable nunjucks caching so changes to templates show immediately
+- Stop watching .html files and restarting the server whenever they are changed
 
 ## 4.10.0 - 22 February 2024
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,7 @@ function startNodemon(done) {
   const server = nodemon({
     script: 'app.js',
     stdout: false,
-    ext: 'scss js html',
+    ext: 'scss js',
     quiet: true,
   });
   let starting = false;


### PR DESCRIPTION
Currently files with the extension `.html` are being watched, which means that whenever they are edited, the nodemon server is restarted.

When combined with the in-memory session storage (which is currently the default), this means that when editing any html file, all data previously entered by the user is wiped. This makes local development of prototypes where data is stored quite tricky.

Since nunjucks is now configured to not cache the files (see #286), we no longer need to watch the HTML files and reload the server, as any changes to the content will still be shown.

Fixes #287

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
