### PR TITLE
Stop watcing scss files from nodemon

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,7 +62,7 @@ function startNodemon(done) {
   const server = nodemon({
     script: 'app.js',
     stdout: false,
-    ext: 'scss js',
+    ext: 'js',
     quiet: true,
   });
   let starting = false;


### PR DESCRIPTION
These are being watched by a separate gulp task.

Thanks @joelanman for pointing this out.