### PR TITLE
Replace keypather with lodash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,5 @@
 // NPM dependencies
-const getKeypath = require('keypather/get');
+const { get: getKeypath } = require('lodash');
 const path = require('path');
 
 // Require core and custom filters, merges to one object

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "gulp-nodemon": "^2.5.0",
         "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
-        "keypather": "^3.1.0",
+        "lodash": "^4.17.21",
         "nhsuk-frontend": "^8.1.1",
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
@@ -2811,32 +2811,6 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/101": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
-      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
-      "dependencies": {
-        "clone": "^1.0.2",
-        "deep-eql": "^0.1.3",
-        "keypather": "^1.10.2"
-      }
-    },
-    "node_modules/101/node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/101/node_modules/keypather": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
-      "integrity": "sha512-hgomDZ+POrsgpkE7qQuSI2ffyfVLJdDLxk8spzWeR33ovNssz6jCWDOIBLEPyI8SAWcQ5njl1ignlqgMrZsGpA==",
-      "dependencies": {
-        "101": "^1.0.0"
-      }
-    },
     "node_modules/a-sync-waterfall": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
@@ -3263,15 +3237,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
-    },
-    "node_modules/assert-err": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assert-err/-/assert-err-1.1.0.tgz",
-      "integrity": "sha512-dEOsK5ngosvrne66QiI3D3nsvTesIMhiiH0tYC5sISAFFzvZza0PFxWWanNcoBX90McFTRsebVkR0ApXxtkGqA==",
-      "dependencies": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      }
     },
     "node_modules/assign-symbols": {
       "version": "1.0.0",
@@ -4754,17 +4719,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
-      "dependencies": {
-        "type-detect": "0.1.1"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/deep-is": {
@@ -10284,26 +10238,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/keypather": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-3.1.0.tgz",
-      "integrity": "sha512-DsxfrBVXlQihWmefW/lNvVgtzFoSoDd67mCsop7a+tK9h7ybpBF5YRUXg192GBmOc3gn4IEv3AV69HElXYuCLA==",
-      "dependencies": {
-        "101": "^1.6.2",
-        "debug": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "shallow-clone": "^3.0.0",
-        "string-reduce": "^1.0.0"
-      }
-    },
-    "node_modules/keypather/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -12638,17 +12572,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "node_modules/shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -13244,14 +13167,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-reduce/-/string-reduce-1.0.0.tgz",
-      "integrity": "sha512-Sc7/l7xG8TvJrC1+LNowFgAyW0jerj73NHPJo66ijTQCbveJ2TRHoq+mACTLzlFTO7V30ESzb23qTU6wB0VNCQ==",
-      "dependencies": {
-        "assert-err": "^1.1.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -13598,14 +13513,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/type-fest": {
@@ -14356,31 +14263,6 @@
     }
   },
   "dependencies": {
-    "101": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
-      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
-      "requires": {
-        "clone": "^1.0.2",
-        "deep-eql": "^0.1.3",
-        "keypather": "^1.10.2"
-      },
-      "dependencies": {
-        "clone": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-          "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="
-        },
-        "keypather": {
-          "version": "1.10.2",
-          "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
-          "integrity": "sha512-hgomDZ+POrsgpkE7qQuSI2ffyfVLJdDLxk8spzWeR33ovNssz6jCWDOIBLEPyI8SAWcQ5njl1ignlqgMrZsGpA==",
-          "requires": {
-            "101": "^1.0.0"
-          }
-        }
-      }
-    },
     "@aashutoshrathi/word-wrap": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
@@ -16677,15 +16559,6 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
     },
-    "assert-err": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assert-err/-/assert-err-1.1.0.tgz",
-      "integrity": "sha512-dEOsK5ngosvrne66QiI3D3nsvTesIMhiiH0tYC5sISAFFzvZza0PFxWWanNcoBX90McFTRsebVkR0ApXxtkGqA==",
-      "requires": {
-        "escape-string-regexp": "^1.0.5",
-        "object-assign": "^4.1.0"
-      }
-    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -17789,14 +17662,6 @@
       "integrity": "sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==",
       "dev": true,
       "requires": {}
-    },
-    "deep-eql": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
-      "requires": {
-        "type-detect": "0.1.1"
-      }
     },
     "deep-is": {
       "version": "0.1.4",
@@ -21977,28 +21842,6 @@
       "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
       "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
     },
-    "keypather": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/keypather/-/keypather-3.1.0.tgz",
-      "integrity": "sha512-DsxfrBVXlQihWmefW/lNvVgtzFoSoDd67mCsop7a+tK9h7ybpBF5YRUXg192GBmOc3gn4IEv3AV69HElXYuCLA==",
-      "requires": {
-        "101": "^1.6.2",
-        "debug": "^3.1.0",
-        "escape-string-regexp": "^1.0.5",
-        "shallow-clone": "^3.0.0",
-        "string-reduce": "^1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -23783,14 +23626,6 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
-    "shallow-clone": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
-      "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
-      "requires": {
-        "kind-of": "^6.0.2"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -24273,14 +24108,6 @@
         }
       }
     },
-    "string-reduce": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string-reduce/-/string-reduce-1.0.0.tgz",
-      "integrity": "sha512-Sc7/l7xG8TvJrC1+LNowFgAyW0jerj73NHPJo66ijTQCbveJ2TRHoq+mACTLzlFTO7V30ESzb23qTU6wB0VNCQ==",
-      "requires": {
-        "assert-err": "^1.1.0"
-      }
-    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -24547,11 +24374,6 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
-    },
-    "type-detect": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA=="
     },
     "type-fest": {
       "version": "0.21.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gulp-nodemon": "^2.5.0",
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
-    "keypather": "^3.1.0",
+    "lodash": "^4.17.21",
     "nhsuk-frontend": "^8.1.1",
     "nunjucks": "^3.2.4",
     "path": "^0.12.7",


### PR DESCRIPTION
keypather is quite old and has some security issues with one of its dependencies. This replaces it with a function from lodash, which is already installed anyway.

Re-applies same update from the GOV.UK Prototype Kit here: https://github.com/alphagov/govuk-prototype-kit/pull/1155