### PR TITLE
Replace basic authentication with a password page and a cookie.

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 
 // External dependencies
 const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser');
 const dotenv = require('dotenv');
 const express = require('express');
 const nunjucks = require('nunjucks');
@@ -22,6 +23,8 @@ const locals = require('./app/locals');
 const routes = require('./app/routes');
 const documentationRoutes = require('./docs/documentation_routes');
 const utils = require('./lib/utils');
+
+const prototypeAdminRoutes = require('./middleware/prototype-admin-routes');
 
 // Set configuration variables
 const port = process.env.PORT || config.port;
@@ -42,11 +45,15 @@ app.locals.useAutoStoreData = (useAutoStoreData === 'true');
 app.locals.useCookieSessionStore = (useCookieSessionStore === 'true');
 app.locals.serviceName = config.serviceName;
 
+// Use cookie middleware to parse cookies
+app.use(cookieParser());
+
 // Nunjucks configuration for application
 const appViews = [
   path.join(__dirname, 'app/views/'),
   path.join(__dirname, 'node_modules/nhsuk-frontend/packages/components'),
   path.join(__dirname, 'docs/views/'),
+  path.join(__dirname, 'lib/prototype-admin/'),
 ];
 
 const nunjucksConfig = {
@@ -70,6 +77,9 @@ const sessionOptions = {
     maxAge: 1000 * 60 * 60 * 4, // 4 hours
   },
 };
+
+// Authentication
+app.use(authentication);
 
 // Support session data in cookie or memory
 if (useCookieSessionStore === 'true' && !onlyDocumentation) {
@@ -130,12 +140,6 @@ if (!sessionDataDefaultsFileExists) {
 
   fs.createReadStream(path.join(__dirname, '/lib/template.session-data-defaults.js'))
     .pipe(fs.createWriteStream(sessionDataDefaultsFile));
-}
-
-// Check if the app is documentation only
-if (onlyDocumentation !== 'true') {
-  // Require authentication if not
-  app.use(authentication);
 }
 
 // Local variables
@@ -212,6 +216,8 @@ app.post('/examples/passing-data/clear-data', (req, res) => {
   req.session.data = {};
   res.render('examples/passing-data/clear-data-success');
 });
+
+app.use('/prototype-admin', prototypeAdminRoutes);
 
 // Redirect all POSTs to GETs - this allows users to use POST for autoStoreData
 app.post(/^\/([^.]+)$/, (req, res) => {

--- a/docs/views/how-tos/publish-your-prototype-online.html
+++ b/docs/views/how-tos/publish-your-prototype-online.html
@@ -35,7 +35,7 @@
       <h2>Setting a password</h2>
       <p>When running the prototype kit online, you must set a password. This is to stop anyone accidentally finding your prototype and mistaking it for a real service.</p>
       <p>To set a password, check your hosting services documentation on how to set "environment variables". (It may have a slightly different name like "config vars" or "variables".)</p>
-      <p>The password should be set using the variable <code class="app-code">PROTOTYPE_USERNAME</code>.</p>
+      <p>The password should be set using the variable <code class="app-code">PROTOTYPE_PASSWORD</code>.</p>
 
       <p>If you are using an older version of the prototype kit (before v4.12.9) you will also need to set a username using the variable <code class="app-code">PROTOTYPE_USERNAME</code>.</p>
 

--- a/docs/views/how-tos/publish-your-prototype-online.html
+++ b/docs/views/how-tos/publish-your-prototype-online.html
@@ -33,13 +33,13 @@
       <p>Some hosting services may automatically deploy your prototype every time you merge new changes in the connected GitHub repository. You may be able to enable automatic deploys. If it hasn't automatically update your prototype, you will need to do this manually.</p>
       
       <h2>Setting a password</h2>
-      <p>When running the prototype kit online, you must set a username and password. This is to stop anyone accidentally finding your prototype and mistaking it for a real service.</p>
+      <p>When running the prototype kit online, you must set a password. This is to stop anyone accidentally finding your prototype and mistaking it for a real service.</p>
       <p>To set a password, check your hosting services documentation on how to set "environment variables". (It may have a slightly different name like "config vars" or "variables".)</p>
-      <p>Set environment variables. For example:</p>
-      <p><code class="app-code">PROTOTYPE_USERNAME</code><code class="app-code">nameofservice</code></p> 
-      <p><code class="app-code">PROTOTYPE_PASSWORD</code><code class="app-code">yourpassword123</code></p>
+      <p>The password should be set using the variable <code class="app-code">PROTOTYPE_USERNAME</code>.</p>
 
-      <p>In Railway, you also need to create:</p> 
+      <p>If you are using an older version of the prototype kit (before v4.12.9) you will also need to set a username using the variable <code class="app-code">PROTOTYPE_USERNAME</code>.</p>
+
+      <p>In Railway, you also need to create:</p>
       <ul>
         <li>a variable called <code class="app-code">NODE-ENV</code> and set the value to <code class="app-code">production</code></li>
         <li>a variable called <code class="app-code">USE_AUTH</code> with the value of <code class="app-code">true</code></li>

--- a/docs/views/how-tos/publish-your-prototype-online.html
+++ b/docs/views/how-tos/publish-your-prototype-online.html
@@ -37,7 +37,7 @@
       <p>To set a password, check your hosting services documentation on how to set "environment variables". (It may have a slightly different name like "config vars" or "variables".)</p>
       <p>The password should be set using the variable <code class="app-code">PROTOTYPE_PASSWORD</code>.</p>
 
-      <p>If you are using an older version of the prototype kit (before v4.12.9) you will also need to set a username using the variable <code class="app-code">PROTOTYPE_USERNAME</code>.</p>
+      <p>If you are using an older version of the prototype kit (before v4.12.0) you will also need to set a username using the variable <code class="app-code">PROTOTYPE_USERNAME</code>.</p>
 
       <p>In Railway, you also need to create:</p>
       <ul>

--- a/lib/prototype-admin/password.html
+++ b/lib/prototype-admin/password.html
@@ -1,0 +1,58 @@
+{% extends 'layout.html' %}
+
+{% block pageTitle %}
+  {% if error == "wrong-password" %}
+    Error:
+  {% endif %}
+  Sign in - NHS Prototype Kit
+{% endblock %}
+
+{% block content %}
+
+  <div class="nhsuk-grid-row">
+    <div class="nhsuk-grid-column-two-thirds">
+      <form method="post" action="/prototype-admin/password">
+
+      {% if error == "wrong-password" %}
+        {{ errorSummary({
+          titleText: "There is a problem",
+          errorList: [
+            {
+              text: "The password is not correct",
+              href: "#password"
+            }
+          ]
+        })}}
+      {% endif %}
+
+        <h1 class="nhsuk-heading-l">
+          This is a prototype used for research
+        </h1>
+
+        <p>
+          It is not a real service. You should only continue if you have been invited to test this prototype.
+        </p>
+
+        {{ input({
+          classes: "nhsuk-input--width-10",
+          name: "password",
+          id: "password",
+          type: "password",
+          errorMessage: {
+            text: "The password is not correct"
+          } if error == "wrong-password",
+          label:{
+              text: "Password"
+          }
+        }) }}
+
+        <input type="hidden" name="returnURL" value="{{returnURL}}">
+
+        {{ button({
+          text: "Continue"
+        }) }}
+
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/lib/prototype-admin/password.html
+++ b/lib/prototype-admin/password.html
@@ -4,7 +4,7 @@
   {% if error == "wrong-password" %}
     Error:
   {% endif %}
-  Sign in - NHS Prototype Kit
+  Enter password - NHS prototype kit
 {% endblock %}
 
 {% block content %}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 // NPM dependencies
 const { get: getKeypath } = require('lodash');
 const path = require('path');
+const crypto = require('crypto');
 
 // Require core and custom filters, merges to one object
 // and then add the methods to Nunjucks environment
@@ -310,3 +311,12 @@ exports.handleCookies = function (app) {
   }
 }
 */
+
+function encryptPassword(password) {
+  if (!password) { return undefined; }
+  const hash = crypto.createHash('sha256');
+  hash.update(password);
+  return hash.digest('hex');
+}
+
+exports.encryptPassword = encryptPassword;

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -10,7 +10,7 @@ const allowedPathsWhenUnauthenticated = [
   '/js/main.js',
 ];
 
-const encryptedPassword = encryptPassword(process.env.PASSWORD);
+const encryptedPassword = encryptPassword(process.env.PROTOTYPE_PASSWORD);
 const nodeEnv = process.env.NODE_ENV || 'development';
 
 // Redirect the user to the password page, with
@@ -37,7 +37,7 @@ function showNoPasswordError(res) {
 function authentication(req, res, next) {
   if (nodeEnv !== 'production') {
     next();
-  } else if (!process.env.PASSWORD) {
+  } else if (!process.env.PROTOTYPE_PASSWORD) {
     showNoPasswordError(res);
   } else if (allowedPathsWhenUnauthenticated.includes(req.path)) {
     next();

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -31,7 +31,7 @@ function sendUserToPasswordPage(req, res) {
 
 // Give the user some instructions on how to set a password
 function showNoPasswordError(res) {
-  return res.send('<h1>Error:</h1><p>Password not set. <a href="#">See guidance for setting a password</a>.</p>');
+  return res.send('<h1>Error:</h1><p>Password not set. <a href="https://nhsuk-prototype-kit.azurewebsites.net/docs/how-tos/publish-your-prototype-online">See guidance for setting a password</a>.</p>');
 }
 
 function authentication(req, res, next) {

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -11,7 +11,7 @@ const allowedPathsWhenUnauthenticated = [
 ];
 
 const encryptedPassword = encryptPassword(process.env.PASSWORD);
-const nodeEnv = process.env.NODE_ENV || 'test';
+const nodeEnv = process.env.NODE_ENV || 'development';
 
 // Redirect the user to the password page, with
 // the current page path set as the returnURL in a query

--- a/middleware/authentication.js
+++ b/middleware/authentication.js
@@ -1,36 +1,51 @@
-/**
- * Simple basic auth middleware for use with Express 4.x.
- *
- * Based on template found at: http://www.danielstjules.com/2014/08/03/basic-auth-with-express-4/
- *
- * @example
- * const authentication = required('authentication');
- * app.use(authentication);
- *
- * @param   {string}   req Express Request object
- * @param   {string}   res Express Response object
- * @returns {function} Express 4 middleware requiring the given credentials
- */
-// External dependencies
-const basicAuth = require('basic-auth');
+const url = require('url');
+const { encryptPassword } = require('../lib/utils');
 
-module.exports = function (req, res, next) { /* eslint-disable-line func-names,consistent-return */
-  // Set configuration variables
-  const env = (process.env.NODE_ENV || 'development').toLowerCase();
-  const username = process.env.PROTOTYPE_USERNAME;
-  const password = process.env.PROTOTYPE_PASSWORD;
+const allowedPathsWhenUnauthenticated = [
+  '/prototype-admin/password',
+  '/css/main.css',
+  '/nhsuk-frontend/nhsuk.min.js',
+  '/js/auto-store-data.js',
+  '/js/jquery-3.5.1.min.js',
+  '/js/main.js',
+];
 
-  if (env === 'production' || env === 'staging') {
-    if (!username || !password) {
-      return res.send('<p>Username or password not set in environment variables.</p>');
-    }
+const encryptedPassword = encryptPassword(process.env.PASSWORD);
+const nodeEnv = process.env.NODE_ENV || 'test';
 
-    const user = basicAuth(req);
+// Redirect the user to the password page, with
+// the current page path set as the returnURL in a query
+// string so the user can be redirected back after successfully
+// entering a password
+function sendUserToPasswordPage(req, res) {
+  const returnURL = url.format({
+    pathname: req.path,
+    query: req.query,
+  });
+  const passwordPageURL = url.format({
+    pathname: '/prototype-admin/password',
+    query: { returnURL },
+  });
+  res.redirect(passwordPageURL);
+}
 
-    if (!user || user.name !== username || user.pass !== password) {
-      res.set('WWW-Authenticate', 'Basic realm=Authorization Required');
-      return res.sendStatus(401);
-    }
+// Give the user some instructions on how to set a password
+function showNoPasswordError(res) {
+  return res.send('<h1>Error:</h1><p>Password not set. <a href="#">See guidance for setting a password</a>.</p>');
+}
+
+function authentication(req, res, next) {
+  if (nodeEnv !== 'production') {
+    next();
+  } else if (!process.env.PASSWORD) {
+    showNoPasswordError(res);
+  } else if (allowedPathsWhenUnauthenticated.includes(req.path)) {
+    next();
+  } else if (req.cookies.authentication === encryptedPassword) {
+    next();
+  } else {
+    sendUserToPasswordPage(req, res);
   }
-  next();
-};
+}
+
+module.exports = authentication;

--- a/middleware/prototype-admin-routes.js
+++ b/middleware/prototype-admin-routes.js
@@ -1,0 +1,37 @@
+const express = require('express');
+
+const router = express.Router();
+
+const password = process.env.PASSWORD;
+
+const { encryptPassword } = require('../lib/utils');
+
+router.get('/password', (req, res) => {
+  const returnURL = req.query.returnURL || '/';
+  const { error } = req.query;
+  res.render('password', {
+    returnURL,
+    error,
+  });
+});
+
+// Check authentication password
+router.post('/password', (req, res) => {
+  const submittedPassword = req.body.password;
+  const { returnURL } = req.body;
+
+  if (submittedPassword === password) {
+    // see lib/middleware/authentication.js for explanation
+    res.cookie('authentication', encryptPassword(password), {
+      maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
+      sameSite: 'None', // Allows GET and POST requests from other domains
+      httpOnly: true,
+      secure: true,
+    });
+    res.redirect(returnURL);
+  } else {
+    res.redirect(`/prototype-admin/password?error=wrong-password&returnURL=${encodeURIComponent(returnURL)}`);
+  }
+});
+
+module.exports = router;

--- a/middleware/prototype-admin-routes.js
+++ b/middleware/prototype-admin-routes.js
@@ -2,7 +2,7 @@ const express = require('express');
 
 const router = express.Router();
 
-const password = process.env.PASSWORD;
+const password = process.env.PROTOTYPE_PASSWORD;
 
 const { encryptPassword } = require('../lib/utils');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,10 +12,10 @@
       "dependencies": {
         "@babel/core": "^7.24.7",
         "@babel/preset-env": "^7.24.7",
-        "basic-auth": "^2.0.1",
         "body-parser": "^1.20.2",
         "browser-sync": "^3.0.2",
         "client-sessions": "^0.8.0",
+        "cookie-parser": "^1.4.6",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-session": "^1.18.0",
@@ -3602,17 +3602,6 @@
         "node": "^4.5.0 || >= 5.9"
       }
     },
-    "node_modules/basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "dependencies": {
-        "safe-buffer": "5.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -4471,6 +4460,26 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -16887,14 +16896,6 @@
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
       "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
-    "basic-auth": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
-      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
-      "requires": {
-        "safe-buffer": "5.1.2"
-      }
-    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -17538,6 +17539,22 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
       "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+    },
+    "cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "requires": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+          "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA=="
+        }
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "dependencies": {
     "@babel/core": "^7.24.7",
     "@babel/preset-env": "^7.24.7",
-    "basic-auth": "^2.0.1",
     "body-parser": "^1.20.2",
     "browser-sync": "^3.0.2",
     "client-sessions": "^0.8.0",
+    "cookie-parser": "^1.4.6",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-session": "^1.18.0",


### PR DESCRIPTION
## Description

This replaces the "basic authentication" (a browser popup asking for a username and password) with a redirect to a page asking users to enter a password.

As well as being more user-friendly, this also helps avoid an issue where some corporate networks have turned of basic authentication in the Edge browser.

The code here heavily borrows from the work done by the GOV.UK Prototype Kit team in https://github.com/alphagov/govuk-prototype-kit/pull/1182

Fixes #323

## Screenshot

<img width="1015" alt="Screenshot of a page saying 'This is a prototype used for research. It is not a real service. You should only continue if you have been invited to test this prototype.' followed by a password box and a Continue button." src="https://github.com/nhsuk/nhsuk-prototype-kit/assets/30665/5e031d15-22bf-4477-8fcd-2d7de329eb30">

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
