### PR TITLE
Fix disabling of ghostMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench:
 
 - Enable console logging for nodemon
+- Fix ghostMode not being disabled correctly
 
 ## 4.11.0 - 27 June 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 :wrench:
 
 - Enable console logging for nodemon
-- Fix ghostMode not being disabled correctly
 
 ## 4.11.0 - 27 June 2024
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -93,7 +93,7 @@ function startBrowserSync(done) {
       port: port + 1000,
       ui: false,
       files: ['app/views/**/*.*', 'docs/views/**/*.*'],
-      ghostmode: false,
+      ghostMode: false,
       open: false,
       notify: true,
       watch: true,


### PR DESCRIPTION
## Description
I was getting annoyed that I couldn't keep two tabs of the prototype open without their urls syncing. The solution is to disable ghost mode. Checking the gulpfile, it looks like that's already intended - but a typo means it wasn't working.

[Browsersync ghostMode docs.](https://browsersync.io/docs/options#option-ghostMode)