### PR TITLE
Convert env port to integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enable console logging for nodemon
 - Replace basic auth with a custom authentication process
 - Update NHS.UK frontend to [v8.3.0](https://github.com/nhsuk/nhsuk-frontend/releases/tag/v8.3.0)
+- Fix setting PORT via the command line ([PR 347](https://github.com/nhsuk/nhsuk-prototype-kit/pull/347))
 
 ## 4.11.0 - 27 June 2024
 

--- a/app.js
+++ b/app.js
@@ -27,7 +27,7 @@ const utils = require('./lib/utils');
 const prototypeAdminRoutes = require('./middleware/prototype-admin-routes');
 
 // Set configuration variables
-const port = process.env.PORT || config.port;
+const port = parseInt(process.env.PORT) || config.port;
 const useDocumentation = process.env.SHOW_DOCS || config.useDocumentation;
 const onlyDocumentation = process.env.DOCS_ONLY;
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ const nodemon = require('gulp-nodemon');
 const config = require('./app/config');
 
 // Set configuration variables
-const port = process.env.PORT || config.port;
+const port = parseInt(process.env.PORT) || config.port;
 
 // Delete all the files in /public build directory
 function cleanPublic() {


### PR DESCRIPTION
Setting `port` directly using `PORT=4000 npm run watch` fails because it's read as a string, and browsersync then attempts to add 1000 to it, resulting in a port of `40001000`. This converts the env variable to an integer.