### PR TITLE
Fix typo in link to service manual

### DIFF
--- a/docs/views/templates/question-page.html
+++ b/docs/views/templates/question-page.html
@@ -47,7 +47,7 @@
           "id": "btn_submit"
         }) }}
 
-        <p>[See the <a href="https://service-manual.nhs.uk/design-system/componnets">NHS digital service manual</a> for examples.]</p>
+        <p>(See the <a href="https://service-manual.nhs.uk/design-system/components">NHS digital service manual</a> for examples.)</p>
 
       </form>
 


### PR DESCRIPTION
Fixes #337

Also changed brackets to parenthesis.