### PR TITLE
Log errors when session data defaults crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove guidance and tutorials - these can now be found online on the [NHS Prototype Kit website](https://prototype-kit.service-manual.nhs.uk) - ([PR 385](https://github.com/nhsuk/nhsuk-prototype-kit/pull/385))
 - Update NHS frontend to 9.1.0
+- Show errors when session data defaults crashes ([PR 402](https://github.com/nhsuk/nhsuk-prototype-kit/pull/402))
 
 ## 5.0.0 - 15 October 2024
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -250,6 +250,7 @@ try {
   sessionDataDefaults = require(sessionDataDefaultsFile);
 } catch (e) {
   console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?'); // eslint-disable-line no-console
+  console.error(e)
 }
 
 // Middleware - store any data sent in session, and pass it to all views

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -248,9 +248,9 @@ const sessionDataDefaultsFile = path.join(__dirname, '../app/data/session-data-d
 try {
   /* eslint-disable-next-line */
   sessionDataDefaults = require(sessionDataDefaultsFile);
-} catch (e) {
+} catch (error) {
   console.error('Could not load the session data defaults from app/data/session-data-defaults.js. Might be a syntax error?'); // eslint-disable-line no-console
-  console.error(e)
+  console.error(error)
 }
 
 // Middleware - store any data sent in session, and pass it to all views


### PR DESCRIPTION
## Description
Fixes #401 

[Fix copied from GOV.UK](https://github.com/alphagov/govuk-prototype-kit/pull/1050) (where I amusingly raised the same issue 5 years ago)