### PR TITLE
Use serviceName local in start page template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # NHS.UK prototype kit Changelog
 
+## Unreleased
+
+- Updated start page template to use the `serviceName` variable in the h1 and title tag ([PR 414](https://github.com/nhsuk/nhsuk-prototype-kit/pull/414))
+
 ## 5.1.0 - 12 November 2024
 
 - Remove guidance and tutorials - these can now be found online on the [NHS Prototype Kit website](https://prototype-kit.service-manual.nhs.uk) - ([PR 385](https://github.com/nhsuk/nhsuk-prototype-kit/pull/385))

--- a/docs/views/templates/start-page.html
+++ b/docs/views/templates/start-page.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Start page template - NHS.UK prototype kit
+  {{ serviceName }}
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/start-page.html
+++ b/docs/views/templates/start-page.html
@@ -16,7 +16,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        Service name goes here
+        {{ serviceName }}
       </h1>
 
       <p>Use this service to:</p>


### PR DESCRIPTION
Currently the [Create pages step](https://prototype-kit.service-manual.nhs.uk/how-tos/build-basic-prototype/create-pages) of the basic prototype tutorial says to copy and paste the `start-page.html` template and then:

> You'll normally edit the HTML to make changes to pages, but the service name is in a config file. This is so we can change it in one place to update it on every page in your prototype.

However currently the `<h1>` and `pageTitle` (used for `<title>` tag) has a hardcoded start name. 🤦

It makes sense for this to be dynamic, so let’s use the local `serviceName` variable instead.

Fixes #413 - thanks @anandamaryon1 for reporting.

## Checklist

- [x] CHANGELOG entry
