### PR TITLE
Use serviceName in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Updated start page template to use the `serviceName` variable in the h1 and title tag ([PR 414](https://github.com/nhsuk/nhsuk-prototype-kit/pull/414))
+- Update Header to use the `serviceName` variable ([PR 417](https://github.com/nhsuk/nhsuk-prototype-kit/pull/417))
 
 ## 5.1.0 - 12 November 2024
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -22,7 +22,7 @@
 {% block header %}
   {{ header({
     "service": {
-        "name": "Prototype kit",
+        "name": serviceName,
         "href": "/"
       },
       "showNav": "false",


### PR DESCRIPTION
Rather than being hardcoded, the service name in the header should use the `serviceName` variable set in `config.js`.

Fixes #416

- [x] CHANGELOG entry
