### PR TITLE
Update default index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Update Header to use the `serviceName` variable ([PR 417](https://github.com/nhsuk/nhsuk-prototype-kit/pull/417))
 - Remove example page template with lots of content examples on it ([PR 420](https://github.com/nhsuk/nhsuk-prototype-kit/pull/420))
 - Update default service name ([PR 419](https://github.com/nhsuk/nhsuk-prototype-kit/pull/419))
+- Update default index page ([PR 423](https://github.com/nhsuk/nhsuk-prototype-kit/pull/423))
 
 ## 5.1.0 - 12 November 2024
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -55,10 +55,10 @@
 
       <ul class="nhsuk-list nhsuk-list--bullet">
         <li>
-          <a href="https://prototype-kit.service-manual.nhs.uk/how-tos">NHS Prototype kit guides</a> – including a tutorial
+          <a href="https://prototype-kit.service-manual.nhs.uk/how-tos">NHS prototype kit guides</a> – including a tutorial
         </li>
         <li>
-          <a href="https://service-manual.nhs.uk/design-system">NHS Digital service manual</a> – for code snippets and guidance on using NHS styles, components and patterns
+          <a href="https://service-manual.nhs.uk/design-system">NHS digital service manual</a> – for code snippets and guidance on using NHS styles, components and patterns
         </li>
       </ul>
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -2,17 +2,17 @@
 
 <!-- ADDING CUSTOM CSS - Add your custom CSS or Sass in /app/assets/sass/main.scss -->
 
-<!-- Extends the layout from /views/layout.html -->
+<!-- Extends the layout from /app/views/layout.html -->
 {% extends 'layout.html' %}
 <!--
-  In /views/layout.html you can:
+  In /app/views/layout.html you can:
     - change the header and footer
     - add custom CSS and JavaScript
 -->
 
 <!-- Set the page title -->
 {% block pageTitle %}
-  NHS.UK prototype kit
+  {{ serviceName }}
 {% endblock %}
 
 <!-- For adding a breadcrumb or back link -->
@@ -20,54 +20,45 @@
 {% block beforeContent %}
 {% endblock %}
 
-
 <!-- For adding page content -->
 <!-- Page layout code can be found at https://service-manual.nhs.uk/design-system/styles/layout -->
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
 
-      <!-- Change the page title here -->
-      <h1>
+      <!-- You can delete the lines below -->
+      <h2 class="nhsuk-heading-l">
         NHS.UK prototype kit
         <span class="nhsuk-caption-xl nhsuk-caption--bottom">Version {{version}}</span>
-      </h1>
+      </h2>
+      <hr>
+
 
       <!-- Add your content here -->
       <!-- Styles and components can be found at https://service-manual.nhs.uk/design-system -->
 
-      <p class="nhsuk-lede-text">
-        This kit lets you rapidly create HTML prototypes of NHS services.
+      <h1 class="nhsuk-heading-xl">
+        {{ serviceName }}
+      </h1>
+
+      <p>Set the service name for your prototype by editing <strong>/app/config.js</strong>.</p>
+
+      <p>
+        This is the index page for your prototype. You can find it at <strong>/app/views/index.html</strong>.
       </p>
 
       <hr>
 
-      <h2>
-        About this page
-      </h2>
-
-      <p>
-        Use this page as the index for your project.
-      </p>
-
-      <p>
-        You'll find the code for this page at <strong>/app/views/index.html</strong>.
-      </p>
-
-      <hr>
-
-      <h2>
+      <h2 class="nhsuk-heading-l">
         Get started
       </h2>
 
-      <p>Get started by using the:</p>
-
-      <ul>
+      <ul class="nhsuk-list nhsuk-list--bullet">
         <li>
-          <a href="https://prototype-kit.service-manual.nhs.uk/how-tos">how to guides</a>
+          <a href="https://prototype-kit.service-manual.nhs.uk/how-tos">NHS Prototype kit guides</a> – including a tutorial
         </li>
         <li>
-          code snippets for styles and components from the <a href="https://service-manual.nhs.uk/design-system">NHS digital service manual</a>
+          <a href="https://service-manual.nhs.uk/design-system">NHS Digital service manual</a> – for code snippets and guidance on using NHS styles, components and patterns
         </li>
       </ul>
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -1,6 +1,6 @@
-<!-- 
+<!--
   This is the main layout where you can:
-    - change the header and footer 
+    - change the header and footer
     - add custom CSS and JavaScript
 -->
 
@@ -41,8 +41,8 @@
         "label": "Home"
       },
       {
-        "URL": "/page-example",
-        "label": "Example page"
+        "URL": "/docs/page-templates",
+        "label": "Example page templates"
       }
     ]
   })}}


### PR DESCRIPTION
Following #419, this updates the default index page to give clearer guidance on how to:

* set the service name (which is now set to "Service name goes here" by default)
* edit the index page
* use the external links and included example templates

Inspired by the GOV.UK Prototype kit default index page.

## Screenshots

| Before | After |
| -------|-------|
| ![index-page-before](https://github.com/user-attachments/assets/5d770089-4523-47fb-9120-f77638de2039) | ![index-page-after](https://github.com/user-attachments/assets/59289a28-9721-4b76-836d-3fe3a3b9c826) |

## Checklist

- [x] CHANGELOG entry
