### PR TITLE
Change all references to 'NHS.UK prototype kit' (except legacy mentions in CHANGELOG.MD )

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# NHS.UK prototype kit Changelog
+# NHS prototype kit Changelog
 
 ## Unreleased
 
@@ -6,6 +6,7 @@
 - Update Header to use the `serviceName` variable ([PR 417](https://github.com/nhsuk/nhsuk-prototype-kit/pull/417))
 - Remove example page template with lots of content examples on it ([PR 420](https://github.com/nhsuk/nhsuk-prototype-kit/pull/420))
 - Update default service name ([PR 419](https://github.com/nhsuk/nhsuk-prototype-kit/pull/419))
+- Changed all references from 'NHS.UK prototype kit' to 'NHS prototype kit'
 
 ## 5.1.0 - 12 November 2024
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution guidelines
 
-Thank you for your interest in contributing to NHS.UK prototype kit, we really appreciate it. There are a number of ways that you can contribute – reporting bugs, fixing bugs, suggesting new features or writing documentation.
+Thank you for your interest in contributing to NHS prototype kit, we really appreciate it. There are a number of ways that you can contribute – reporting bugs, fixing bugs, suggesting new features or writing documentation.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# NHS.UK prototype kit
+# NHS prototype kit
 
-Visit the <a href="https://prototype-kit.service-manual.nhs.uk">NHS.UK prototype kit site</a> to download the latest version and read the documentation.
+Visit the <a href="https://prototype-kit.service-manual.nhs.uk">NHS prototype kit site</a> to download the latest version and read the documentation.
 
-## About the NHS.UK prototype kit
+## About the NHS prototype kit
 
-The NHS.UK prototype kit enables you to make interactive prototypes that will look like pages on NHS.UK. The prototypes you make are a great way to show ideas to others and for conducting user research.
+The NHS prototype kit enables you to make interactive prototypes that will look like pages on NHS.UK. The prototypes you make are a great way to show ideas to others and for conducting user research.
 
 ## Security
 
@@ -23,7 +23,7 @@ Start the kit with `npm run watch`.
 
 ## Contribute
 
-If you want to contribute to the NHS.UK prototype kit, by reporting bugs, fixing bugs, suggesting new features or writing documentation, then read our [contributing guidelines](CONTRIBUTING.md).
+If you want to contribute to the NHS prototype kit, by reporting bugs, fixing bugs, suggesting new features or writing documentation, then read our [contributing guidelines](CONTRIBUTING.md).
 
 ## Development environment
 
@@ -66,4 +66,4 @@ Code analysis results can be found in [SonarQube](https://sonar.nhswebsite.nhs.u
 
 ## Support
 
-The NHS.UK prototype kit is maintained by NHS England. [Email us](mailto:service-manual@nhs.net), open a [Github issue](https://github.com/nhsuk/nhsuk-prototype-kit/issues/new) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).
+The NHS prototype kit is maintained by NHS England. [Email us](mailto:service-manual@nhs.net), open a [Github issue](https://github.com/nhsuk/nhsuk-prototype-kit/issues/new) or get in touch on the [NHS digital service manual Slack workspace](https://join.slack.com/t/nhs-service-manual/shared_invite/enQtNTIyOTEyNjU3NDkyLTk4NDQ3YzkwYzk1Njk5YjAxYTI5YTVkZmUxMGQ0ZjA3NjMyM2ZkNjBlMWMxODVjZjYzNzg1ZmU4MWY1NmE2YzE).

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -12,7 +12,7 @@
 
 <!-- Set the page title -->
 {% block pageTitle %}
-  NHS.UK prototype kit
+  NHS prototype kit
 {% endblock %}
 
 <!-- For adding a breadcrumb or back link -->
@@ -29,7 +29,7 @@
 
       <!-- Change the page title here -->
       <h1>
-        NHS.UK prototype kit
+        NHS prototype kit
         <span class="nhsuk-caption-xl nhsuk-caption--bottom">Version {{version}}</span>
       </h1>
 

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -14,7 +14,7 @@
 
 <!-- Set the page title -->
 {% block pageTitle %}
-  NHS.UK prototype kit
+  NHS prototype kit
 {% endblock %}
 
 <!-- Edit the header -->

--- a/docs/views/layout.html
+++ b/docs/views/layout.html
@@ -6,14 +6,14 @@
 {% endblock %}
 
 {% block pageTitle %}
-  NHS.UK prototype kit
+  NHS prototype kit
 {% endblock %}
 
 {% block header %}
   <header class="nhsuk-header" role="banner">
     <div class="nhsuk-header__container">
       <div class="nhsuk-header__logo nhsuk-header__logo--only">
-        <a class="nhsuk-header__link nhsuk-header__link--service" href="/" aria-label="NHS.UK prototype kit home">
+        <a class="nhsuk-header__link nhsuk-header__link--service" href="/" aria-label="NHS prototype kit home">
           <svg class="nhsuk-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40 16" height="40" width="100">
             <path class="nhsuk-logo__background" fill="#005eb8" d="M0 0h40v16H0z"></path>
             <path class="nhsuk-logo__text" fill="#fff" d="M3.9 1.5h4.4l2.6 9h.1l1.8-9h3.3l-2.8 13H9l-2.7-9h-.1l-1.8 9H1.1M17.3 1.5h3.6l-1 4.9h4L25 1.5h3.5l-2.7 13h-3.5l1.1-5.6h-4.1l-1.2 5.6h-3.4M37.7 4.4c-.7-.3-1.6-.6-2.9-.6-1.4 0-2.5.2-2.5 1.3 0 1.8 5.1 1.2 5.1 5.1 0 3.6-3.3 4.5-6.4 4.5-1.3 0-2.9-.3-4-.7l.8-2.7c.7.4 2.1.7 3.2.7s2.8-.2 2.8-1.5c0-2.1-5.1-1.3-5.1-5 0-3.4 2.9-4.4 5.8-4.4 1.6 0 3.1.2 4 .6"></path>

--- a/docs/views/page-templates.html
+++ b/docs/views/page-templates.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Page templates - NHS.UK prototype kit
+  Page templates - NHS prototype kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/template.html
+++ b/docs/views/template.html
@@ -40,7 +40,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
 
-    <title>{% block pageTitle %}NHS.UK prototype kit{% endblock %}</title>
+    <title>{% block pageTitle %}NHS prototype kit{% endblock %}</title>
 
     <link href="https://www.nhs.uk/" rel="preconnect">
     <link href="https://assets.nhs.uk/" rel="preconnect" crossorigin>

--- a/docs/views/templates/blank-nhsuk.html
+++ b/docs/views/templates/blank-nhsuk.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Blank template - NHS.UK prototype kit
+  Blank template - NHS prototype kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/blank-transactional.html
+++ b/docs/views/templates/blank-transactional.html
@@ -3,7 +3,7 @@
 {% set mainClasses = "nhsuk-main-wrapper--s" %}
 
 {% block pageTitle %}
-  Blank transactional template - NHS.UK prototype kit
+  Blank transactional template - NHS prototype kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/check-your-answers.html
+++ b/docs/views/templates/check-your-answers.html
@@ -3,7 +3,7 @@
 {% set mainClasses = "nhsuk-main-wrapper--s" %}
 
 {% block pageTitle %}
-  Check your answers template - NHS.UK prototype kit
+  Check your answers template - NHS prototype kit
 {% endblock %}
 
 {% block beforeContent %}

--- a/docs/views/templates/confirmation-page.html
+++ b/docs/views/templates/confirmation-page.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Confirmation page template - NHS.UK prototype kit
+  Confirmation page template - NHS prototype kit
 {% endblock %}
 
 {% block content %}

--- a/docs/views/templates/content-page.html
+++ b/docs/views/templates/content-page.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% block pageTitle %}
-  Content page template - NHS.UK prototype kit
+  Content page template - NHS prototype kit
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
## Description

Changing all references to 'NHS.UK prototype kit' to 'NHS prototype kit' (except for past references in the CHANGELOG.MD).

This is to align with direction from @sarawilcox on the service manaual team and the prototype kit new guidance which is already changed.

## Checklist

frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
