### PR TITLE
Simplify comments filters

### DIFF
--- a/app/filters.js
+++ b/app/filters.js
@@ -1,5 +1,4 @@
 module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
-
   const filters = {};
 
   /* ------------------------------------------------------------------

--- a/app/filters.js
+++ b/app/filters.js
@@ -1,10 +1,5 @@
 module.exports = function (env) { /* eslint-disable-line func-names,no-unused-vars */
-  /**
-   * Instantiate object used to store the methods registered as a
-   * 'filter' (of the same name) within nunjucks. You can override
-   * gov.uk core filters by creating filter methods of the same name.
-   * @type {Object}
-   */
+
   const filters = {};
 
   /* ------------------------------------------------------------------
@@ -38,8 +33,6 @@ module.exports = function (env) { /* eslint-disable-line func-names,no-unused-va
 
   ------------------------------------------------------------------ */
 
-  /* ------------------------------------------------------------------
-    keep the following line to return your filters to the app
-  ------------------------------------------------------------------ */
+  /* keep the following line to return your filters to the app  */
   return filters;
 };


### PR DESCRIPTION
Noticed that the comments in `app/filters.js` mention "gov.uk core filters" - presumably leftover from forking from the govuk prototype kit.

Have taken the opportunity to simplify the comments blocks.

The middle comments block could be updated to point to some guidance on https://prototype-kit.service-manual.nhs.uk when it’s ready.

Spotted when reviewing https://github.com/nhsuk/nhsuk.service-manual.prototype-kit.docs/pull/158