### PR TITLE
Update the release process description

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,17 @@ Read an <a href="https://www.gitpod.io/docs">introduction to Gitpod (on Gitpod's
 
 Run unit tests locally with `npm run test`.
 
-### Environments
+### Making changes
 
-### Versioning and releasing
+- Merge required changes via pull requests into `main` branch. As you do so, document changes in the `CHANGELOG.md` under an 'Unreleased' header at the top.
 
-- Merge required changes via PR into `main` branch
-  - Ensure the version number in `package.json` and `CHANGELOG.md` match, with a summary of the changes included in the changelog
-- Pull down merged `main` branch to your local repository
-- Create a tag with the version number from the latest commit on `main`
-  - If the latest version you're looking to push is version "1.2.3", you can do this on the command line with
-    - `git tag v1.2.3`
-    - `git push --tags`
-- [Github actions](https://github.com/nhsuk/nhsuk-prototype-kit/actions/workflows/release.yml) will spring to life and create a release which will be visible on the [releases tab](https://github.com/nhsuk/nhsuk-prototype-kit/releases) of the repository.
-- Finally, edit the description of the release to match the content entered into the changelog.
-- To deploy the changes to Live, the promotion to Live from the Preview environment must have the appropriate approval in Azure.
+### Releasing
+
+- Open a new pull request which changes the version number in `package.json` and `package-lock.json` and which updates the 'Unreleased' header in the `CHANGELOG.md` to the new version number and release date. Merge this into `main`.
+- Visit the [Create a new release page](https://github.com/nhsuk/nhsuk-prototype-kit/releases/new) on GitHub. In the 'Choose a tag' dropdown, create a new tag for the new version number, prefixed with a `v`. Use the same format for the release title. You can use the 'Generate release notes' feature to generate some initial release notes, and then edit these as needed. Make sure the "Set as latest release" checkbox is checked. Publish the release (or save as draft if you’re not ready).
+- Update the `prototypeKitVersion` value in [the `package.json` of the prototype kit website](https://github.com/nhsuk/nhsuk.service-manual.prototype-kit.docs/blob/main/package.json#L4) - this will update the 'Download' link to point to the new zip file.
+- Add some details about the new release to the [What’s new page](https://github.com/nhsuk/nhsuk.service-manual.prototype-kit.docs/blob/main/app/views/whats-new/updates.html) on the prototype kit website
+- Announce the new release on the Service Manual Slack, NHS England Slack, and any other appropriate locations
 
 ### Code Analysis
 


### PR DESCRIPTION
Updated notes on the release process.

Probably this shouldn’t be in the README for the kit itself (as that might be confusing for anyone who gets a copy of it with their prototype) - but there is an existing note saying it’s only for the team.  Perhaps in future it could get moved somewhere else.