### PR TITLE
Removing image attribute from devcontainer to ensure standard linux image is used by Github Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
   "name": "NHS Prototype Kit",
-  "image": "mcr.microsoft.com/devcontainers/universal:2",
   // codespaces seems to have an issue using port 2000 so setting to 2001 for the NHS Prototype Kit
   "runArgs": ["--env", "PORT=2001"],
   "portsAttributes": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS prototype kit Changelog
 
+## [Unreleased]
+
+### Updated
+
+- Updated .devcontainer to remove the image attribute ([PR 451](https://github.com/nhsuk/nhsuk-prototype-kit/pull/451))
+
 ## 5.2.0 - 13 December 2024
 
 - Updated start page template to use the `serviceName` variable in the h1 and title tag ([PR 414](https://github.com/nhsuk/nhsuk-prototype-kit/pull/414))


### PR DESCRIPTION
## Description

Removing the attribute to set the image, as the default linux image is excluded from (does not contribute to) storage usage limits of a Codespace.

## Checklist

- [x] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
