### PR TITLE
Add note to checked function

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,9 @@ exports.addNunjucksFilters = function (env) { /* eslint-disable-line func-names 
 };
 
 // Add Nunjucks function called 'checked' to populate radios and checkboxes
+// This function is less useful since NHS Frontend 9.2.0 added an
+// easier way to set checkbox and radio checked items, and may
+// be removed in future.
 exports.addCheckedFunction = function (env) { /* eslint-disable-line func-names */
   env.addGlobal('checked', function (name, value) { /* eslint-disable-line func-names */
     // Check data exists


### PR DESCRIPTION
The `checked` function is less important now that you can set checked radios and checkboxes much more easily using `value:` or `values:` but we can keep the function for backwards-compatibility.

This PR adds a note to suggest it could be removed in future.