### PR TITLE
Configure Dependabot to ignore SASS upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    ignore:
+      - dependency-name: "sass-embedded"
+      # SASS updates will be done manually in sync with
+      # NHS Frontend to avoid deprecation warnings.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,6 @@ updates:
     schedule:
       interval: 'daily'
     ignore:
-      - dependency-name: "sass-embedded"
       # SASS updates will be done manually in sync with
       # NHS Frontend to avoid deprecation warnings.
+      - dependency-name: 'sass-embedded'


### PR DESCRIPTION
Following the downgrade of SASS in #489 this configures Dependabot to ignore SASS upgrades for now, as we’ll do them manually in sync with NHS Frontend.

This is mostly to avoid prototype kit users seeing lots of deprecation warnings which they are unable to fix.
