### PR TITLE
Improve CSS error logging

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,6 +8,7 @@ const clean = require('gulp-clean');
 const gulpSass = require('gulp-sass')
 const dartSass = require('sass-embedded')
 const nodemon = require('gulp-nodemon');
+const PluginError = require('plugin-error')
 
 // Local dependencies
 const config = require('./app/config');
@@ -23,15 +24,20 @@ function cleanPublic() {
 const sass = gulpSass(dartSass)
 
 // Compile SASS to CSS
-function compileStyles() {
+function compileStyles(done) {
   return gulp
     .src(['app/assets/sass/**/*.scss'])
-    .pipe(sass())
+    .pipe(
+      sass()
+      .on('error', (error) => {
+        done(
+          new PluginError('compileCSS', error.messageFormatted, {
+            showProperties: false
+          })
+        )
+      })
+    )
     .pipe(gulp.dest('public/css'))
-    .on('error', (err) => {
-      console.log(err);
-      process.exit(1);
-    });
 }
 
 // Compile JavaScript (with ES6 support)

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "nhsuk-frontend": "^9.3.0",
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
+        "plugin-error": "^2.0.1",
         "sass-embedded": "1.77.5"
       },
       "devDependencies": {
@@ -6809,6 +6810,21 @@
         "@babel/core": "^7.0.0"
       }
     },
+    "node_modules/gulp-babel/node_modules/plugin-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/gulp-clean": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/gulp-clean/-/gulp-clean-0.4.0.tgz",
@@ -6833,6 +6849,21 @@
         "plugin-error": "1.0.1",
         "through2": "3.0.1",
         "vinyl-sourcemaps-apply": "0.2.1"
+      }
+    },
+    "node_modules/gulp-clean-css/node_modules/plugin-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/gulp-clean-css/node_modules/through2": {
@@ -7871,6 +7902,21 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/gulp-sass/node_modules/plugin-error": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-colors": "^1.0.1",
+        "arr-diff": "^4.0.0",
+        "arr-union": "^3.1.0",
+        "extend-shallow": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/gulp-sass/node_modules/replace-ext": {
@@ -11917,17 +11963,15 @@
       }
     },
     "node_modules/plugin-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
+      "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
+      "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
+        "ansi-colors": "^1.0.1"
       },
       "engines": {
-        "node": ">= 0.10"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/portscanner": {
@@ -19907,6 +19951,19 @@
         "replace-ext": "^1.0.0",
         "through2": "^2.0.0",
         "vinyl-sourcemaps-apply": "^0.2.0"
+      },
+      "dependencies": {
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          }
+        }
       }
     },
     "gulp-clean": {
@@ -19978,6 +20035,17 @@
         "vinyl-sourcemaps-apply": "0.2.1"
       },
       "dependencies": {
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          }
+        },
         "through2": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
@@ -20759,6 +20827,17 @@
           "version": "5.0.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "plugin-error": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+          "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+          "requires": {
+            "ansi-colors": "^1.0.1",
+            "arr-diff": "^4.0.0",
+            "arr-union": "^3.1.0",
+            "extend-shallow": "^3.0.2"
+          }
         },
         "replace-ext": {
           "version": "2.0.0",
@@ -23737,14 +23816,11 @@
       }
     },
     "plugin-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
-      "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-2.0.1.tgz",
+      "integrity": "sha512-zMakqvIDyY40xHOvzXka0kUvf40nYIuwRE8dWhti2WtjQZ31xAgBZBhxsK7vK3QbRXS1Xms/LO7B5cuAsfB2Gg==",
       "requires": {
-        "ansi-colors": "^1.0.1",
-        "arr-diff": "^4.0.0",
-        "arr-union": "^3.1.0",
-        "extend-shallow": "^3.0.2"
+        "ansi-colors": "^1.0.1"
       }
     },
     "portscanner": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash": "^4.17.21",
     "nhsuk-frontend": "^9.3.0",
     "nunjucks": "^3.2.4",
+    "plugin-error": "^2.0.1",
     "path": "^0.12.7",
     "sass-embedded": "1.77.5"
   },


### PR DESCRIPTION
The existing code to output CSS compile errors:

```js
.on('error', (err) => {
  console.log(err);
  process.exit(1);
})
```

..doesn’t seem to actually work. This fixes it, and uses the [plugin-error](https://www.npmjs.com/package/plugin-error) npm module for improved formatting.

(this copies what was done in NHS Frontend in [#1152](https://github.com/nhsuk/nhsuk-frontend/pull/1152))