### PR TITLE
Upgrade NHS Frontend to 9.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
         "lodash": "^4.17.21",
-        "nhsuk-frontend": "^9.3.0",
+        "nhsuk-frontend": "^9.4.1",
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
         "plugin-error": "^2.0.1",
@@ -11229,12 +11229,12 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nhsuk-frontend": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.3.0.tgz",
-      "integrity": "sha512-XZqmZN8YMK/j5cHi7O5AEDigFzPPZJFhBOPkYO/kNIw6k3eveedfRZetgVzOVurI7GUQmWd9IF67eVwR8LFh7w==",
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.4.1.tgz",
+      "integrity": "sha512-0++l57I4qvAYInYJytwU57pRt5j5iQ2bYjD8PfJUfpMNLep0yOmcS2hwwr+JvhexT8pM07VwngK1wUzhCSOaQQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.0.0"
+        "node": "^20.9.0 || ^22.11.0"
       }
     },
     "node_modules/node-int64": {
@@ -23282,9 +23282,9 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "nhsuk-frontend": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.3.0.tgz",
-      "integrity": "sha512-XZqmZN8YMK/j5cHi7O5AEDigFzPPZJFhBOPkYO/kNIw6k3eveedfRZetgVzOVurI7GUQmWd9IF67eVwR8LFh7w=="
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.4.1.tgz",
+      "integrity": "sha512-0++l57I4qvAYInYJytwU57pRt5j5iQ2bYjD8PfJUfpMNLep0yOmcS2hwwr+JvhexT8pM07VwngK1wUzhCSOaQQ=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
     "lodash": "^4.17.21",
-    "nhsuk-frontend": "^9.3.0",
+    "nhsuk-frontend": "^9.4.1",
     "nunjucks": "^3.2.4",
     "plugin-error": "^2.0.1",
     "path": "^0.12.7",


### PR DESCRIPTION
No breaking changes.

A separate PR will switch to using the new Nunjucks template that is now included within NHS Frontend.