### PR TITLE
Fix example template view config

### DIFF
--- a/app.js
+++ b/app.js
@@ -175,14 +175,7 @@ app.get(/^([^.]+)$/, (req, res, next) => {
 // Example template routes
 app.use('/example-templates', exampleTemplatesApp);
 
-// Nunjucks configuration for example templates
-const exampleTemplateViews = [
-  path.join(__dirname, 'lib/example-templates/'),
-  path.join(__dirname, 'node_modules/nhsuk-frontend/packages/components'),
-  path.join(__dirname, 'node_modules/nhsuk-frontend/packages/macros'),
-];
-
-nunjucksAppEnv = nunjucks.configure(exampleTemplateViews, {
+nunjucksAppEnv = nunjucks.configure(appViews, {
   autoescape: true,
   express: exampleTemplatesApp,
 });


### PR DESCRIPTION
#499 accidentally broke the rendering of the example templates, as these are configured separately and were using different view paths.

This fixes it by using the same view config for both. I think this makes sense, rather than duplicating it, as the example templates are mainly designed to be copied-and-pasted into the `app/views` folder.