### PR TITLE
Add more detailed upgrade instructions to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,36 @@
 
 ## Unreleased
 
-- Update NHS.UK frontend to 9.4.1
-- Switch to using the `template.njk` that is now included within NHS Frontend ([PR 499](https://github.com/nhsuk/nhsuk-prototype-kit/pull/499))
+### Breaking changes
+
+- Upgrades NHS.UK frontend to 9.4.1 and switches to using a new `prototype-kit-template.njk` within `lib/templates/` which itself uses the `template.njk` that is now included within NHS Frontend ([PR 499](https://github.com/nhsuk/nhsuk-prototype-kit/pull/499))
+
+In your `layout.html`, change
+
+```njk
+{% extends "template.html" %}
+```
+
+to:
+
+```njk
+{% extends "prototype-kit-template.njk" %}
+```
+
+and change:
+
+```njk
+{% block headCSS %}
+```
+
+to
+
+```njk
+{% block head %}
+```
+
+### Other changes
+
 - Remove ‘Check your answers’ example template, as this is now available on the NHS design system website ([PR 503](https://github.com/nhsuk/nhsuk-prototype-kit/pull/503))
 - Remove Confirmation page example template, as this is now available on the NHS design system website as a pattern ([PR 504](https://github.com/nhsuk/nhsuk-prototype-kit/pull/504))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Breaking changes
 
-- Switches to a new template included within NHS.UK frontend 9.4.1 to make future updates easier ([PR 499](https://github.com/nhsuk/nhsuk-prototype-kit/pull/499))
+- Switches to a new template included within NHS.UK frontend 9.4.1 to make future updates easier ([PR 499](https://github.com/nhsuk/nhsuk-prototype-kit/pull/499)).
 
-In your `layout.html`, change
+To update, first follow the instructions in [Updating the kit](https://prototype-kit.service-manual.nhs.uk/how-tos/updating-the-kit) to update all the files in `lib/`, as well as `app.js` and `package.json`.
+
+Then in your `app/layout.html` file, change
 
 ```njk
 {% extends "template.html" %}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Breaking changes
 
-- Upgrades NHS.UK frontend to 9.4.1 and switches to using a new `prototype-kit-template.njk` within `lib/templates/` which itself uses the `template.njk` that is now included within NHS Frontend ([PR 499](https://github.com/nhsuk/nhsuk-prototype-kit/pull/499))
+- Switches to a new template included within NHS.UK frontend 9.4.1 to make future updates easier ([PR 499](https://github.com/nhsuk/nhsuk-prototype-kit/pull/499))
 
 In your `layout.html`, change
 


### PR DESCRIPTION
This improves the CHANGELOG with more detailed upgrade instructions following the change in #499 to switch to using a new template that’s included within NHS.UK frontend.