### PR TITLE
Remove stub test for app filters

### DIFF
--- a/tests/app/filters.test.js
+++ b/tests/app/filters.test.js
@@ -1,7 +1,0 @@
-const filters = require('../../app/filters');
-
-test('test filters returns empty', () => {
-    const result = filters();
-
-    expect(result).toStrictEqual({});
-});


### PR DESCRIPTION
This test simply asserts that there are no filters set up in `app/filters.js`.

This means that if you add any custom filters, the test will fail. Whilst this could be useful as a prompt for users to create tests for their own filters, we don't want to require all users to do this, and it's likely unnecessary for a prototype.