### PR TITLE
Stop reporting test coverage by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "gulp build",
     "postinstall": "npm run build",
     "start": "node app.js",
-    "test": "jest --coverage=true",
+    "test": "jest app.js lib/**/*.js",
     "test:ci": "jest --ci",
     "prewatch": "gulp build",
     "watch": "gulp",


### PR DESCRIPTION
This just makes the test results harder to immediately spot (you have to scroll up), and is currently misleading as it doesn’t report on coverage of `app.js` or most of the files in `lib/`.