### PR TITLE
Update to nhsuk frontend 9.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix to include the NHS javascript in the default template ([PR 518](https://github.com/nhsuk/nhsuk-prototype-kit/pull/518)).
+- Update to NHS frontend 9.5.2 ([PR 521](https://github.com/nhsuk/nhsuk-prototype-kit/pull/521))
 
 ## 6.0.0 - 7 May 2025
 

--- a/app/assets/sass/components/_related-nav.scss
+++ b/app/assets/sass/components/_related-nav.scss
@@ -5,7 +5,7 @@
 .nhsuk-related-nav {
   border-top: 1px solid $nhsuk-border-color;
 
-  @include mq($until: desktop) {
+  @include nhsuk-media-query($until: desktop) {
     margin-top: nhsuk-spacing(7);
   }
 }

--- a/app/assets/sass/components/_related-nav.scss
+++ b/app/assets/sass/components/_related-nav.scss
@@ -11,14 +11,14 @@
 }
 
 .nhsuk-related-nav__heading {
-  @include nhsuk-typography-responsive(19, $override-line-height: 1.2);
+  @include nhsuk-font-size(19, $line-height: 1.2);
 
   margin-bottom: 12px;
   padding-top: nhsuk-spacing(3);
 }
 
 .nhsuk-related-nav__list {
-  @include nhsuk-typography-responsive(16);
+  @include nhsuk-font-size(16);
 
   list-style: none;
   padding-left: 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "gulp-rename": "^2.0.0",
         "gulp-sass": "^5.1.0",
         "lodash": "^4.17.21",
-        "nhsuk-frontend": "^9.4.1",
+        "nhsuk-frontend": "^9.5.2",
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
         "plugin-error": "^2.0.1",
@@ -9662,10 +9662,13 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
     },
     "node_modules/nhsuk-frontend": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.4.1.tgz",
-      "integrity": "sha512-0++l57I4qvAYInYJytwU57pRt5j5iQ2bYjD8PfJUfpMNLep0yOmcS2hwwr+JvhexT8pM07VwngK1wUzhCSOaQQ==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/nhsuk-frontend/-/nhsuk-frontend-9.5.2.tgz",
+      "integrity": "sha512-s/wjnnJtLZMHGhCcUY6CnI+m0vrJKHc2K1BekbcCm2jk9lwgSODJuXfxaGbESygLs+ly0UfJAcagd5RYxDh5iw==",
       "license": "MIT",
+      "workspaces": [
+        "."
+      ],
       "engines": {
         "node": "^20.9.0 || ^22.11.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "gulp-rename": "^2.0.0",
     "gulp-sass": "^5.1.0",
     "lodash": "^4.17.21",
-    "nhsuk-frontend": "^9.4.1",
+    "nhsuk-frontend": "^9.5.2",
     "nunjucks": "^3.2.4",
     "plugin-error": "^2.0.1",
     "path": "^0.12.7",


### PR DESCRIPTION
This updates the NHS prototype kit to NHS frontend 9.5.2

The update is backwards-compatible, but there are some newly introduced deprecations, which have been fixed.

## Checklist

- [x] CHANGELOG entry
