### PR TITLE
Make it easier to set title tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Make it easier to set page titles ([PR #541](https://github.com/nhsuk/nhsuk-prototype-kit/pull/541))
 - Update to NHS frontend 9.6.2 ([PR #540](https://github.com/nhsuk/nhsuk-prototype-kit/pull/540))
 
 ## 6.2.0 - 23 May 2025

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -10,10 +10,14 @@
     - add custom CSS and JavaScript
 -->
 
-<!-- Set the page title -->
-{% block pageTitle %}
-  {{ serviceName }}
-{% endblock %}
+<!--
+  Use this to set the page name which will appear at the
+  start of the <title> tag, followed by the service name.
+  This can be set to false on a homepage, where only the
+  service name is needed. You can also reuse this variable
+  within the <h1>, where they should be the same.
+-->
+{% set pageName = false %}
 
 <!-- For adding a breadcrumb or back link -->
 <!-- Code examples can be found at https://service-manual.nhs.uk/design-system/components/breadcrumbs and https://service-manual.nhs.uk/design-system/components/back-link -->

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -13,9 +13,9 @@
 <!--
   Use this to set the page name which will appear at the
   start of the <title> tag, followed by the service name.
-  This can be set to false on a homepage, where only the
+  This is often not needed on the homepage, where only the
   service name is needed. You can also reuse this variable
-  within the <h1>, where they should be the same.
+  within the <h1>, where they are the same.
 -->
 {% set pageName = "" %}
 

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -17,7 +17,7 @@
   service name is needed. You can also reuse this variable
   within the <h1>, where they should be the same.
 -->
-{% set pageName = false %}
+{% set pageName = "" %}
 
 <!-- For adding a breadcrumb or back link -->
 <!-- Code examples can be found at https://service-manual.nhs.uk/design-system/components/breadcrumbs and https://service-manual.nhs.uk/design-system/components/back-link -->

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -13,11 +13,6 @@
   <script src="/nhsuk-frontend/nhsuk.min.js" defer></script>
 {% endblock %}
 
-<!-- Set the page title -->
-{% block pageTitle %}
-  NHS prototype kit
-{% endblock %}
-
 <!-- Edit the header -->
 <!-- Header code examples can be found at https://service-manual.nhs.uk/design-system/components/header -->
 {% block header %}

--- a/lib/example-templates/blank-transactional.html
+++ b/lib/example-templates/blank-transactional.html
@@ -2,9 +2,7 @@
 
 {% set mainClasses = "nhsuk-main-wrapper--s" %}
 
-{% block pageTitle %}
-  Blank transactional template - NHS prototype kit
-{% endblock %}
+{% set pageName = "Blank transactional template" %}
 
 {% block beforeContent %}
   {{ backLink({

--- a/lib/example-templates/content-page.html
+++ b/lib/example-templates/content-page.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Content page template - NHS prototype kit
-{% endblock %}
+{% set pageName = "Example content page" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -17,7 +15,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        Page heading goes here
+        {{ pageName }}
       </h1>
 
       <p>

--- a/lib/example-templates/example-templates.html
+++ b/lib/example-templates/example-templates.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Page templates - NHS prototype kit
-{% endblock %}
+{% set pageName = "Page templates" %}
 
 {% block beforeContent %}
   {{ breadcrumb({
@@ -16,7 +14,7 @@
 
     <div class="nhsuk-grid-column-two-thirds">
 
-      <h1>Page templates</h1>
+      <h1>{{ pageName }}</h1>
 
       <p>You can find these templates in the <strong>/lib/example-templates</strong> folder.</p>
 

--- a/lib/example-templates/mini-hub/index.html
+++ b/lib/example-templates/mini-hub/index.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Mini hub - Main page
-{% endblock %}
+{% set pageName = "Mini hub" %}
 
 {% block beforeContent %}
   {{ breadcrumb({

--- a/lib/example-templates/mini-hub/page-2.html
+++ b/lib/example-templates/mini-hub/page-2.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Mini hub - Page two
-{% endblock %}
+{% set pageName = "Mini hub - Page two" %}
 
 {% block beforeContent %}
   {{ breadcrumb({

--- a/lib/example-templates/mini-hub/page-3.html
+++ b/lib/example-templates/mini-hub/page-3.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Mini hub - Page three
-{% endblock %}
+{% set pageName = "Mini hub - Page three" %}
 
 {% block beforeContent %}
   {{ breadcrumb({

--- a/lib/example-templates/question-page.html
+++ b/lib/example-templates/question-page.html
@@ -2,9 +2,7 @@
 
 {% set mainClasses = "nhsuk-main-wrapper--s" %}
 
-{% block pageTitle %}
-  Question page
-{% endblock %}
+{% set pageName = "Question goes here" %}
 
 {% block beforeContent %}
   {{ backLink({
@@ -24,7 +22,7 @@
           "name": "example",
           "fieldset": {
             "legend": {
-              "text": "Heading or question goes here",
+              "text": pageName,
               "classes": "nhsuk-fieldset__legend--l",
               "isPageHeading": true
             }

--- a/lib/example-templates/start-page.html
+++ b/lib/example-templates/start-page.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  {{ serviceName }}
-{% endblock %}
+{% set pageName = serviceName %}
 
 {% block beforeContent %}
 {{ breadcrumb({
@@ -16,7 +14,7 @@
     <div class="nhsuk-grid-column-two-thirds">
 
       <h1>
-        {{ serviceName }}
+        {{ pageName }}
       </h1>
 
       <p>Use this service to:</p>

--- a/lib/prototype-admin/password.html
+++ b/lib/prototype-admin/password.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 
 {% set pageName = "Enter password" %}
-{% set errorsPresent = (error == "wrong-password") %}
+{% set errors = error == "wrong-password" %}
 
 {% block content %}
 

--- a/lib/prototype-admin/password.html
+++ b/lib/prototype-admin/password.html
@@ -1,11 +1,7 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  {% if error == "wrong-password" %}
-    Error:
-  {% endif %}
-  Enter password - NHS prototype kit
-{% endblock %}
+{% set pageName = "Enter password" %}
+{% set errorsPresent = (error == "wrong-password") %}
 
 {% block content %}
 

--- a/lib/prototype-admin/reset-done.html
+++ b/lib/prototype-admin/reset-done.html
@@ -1,13 +1,11 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Data reset - NHS prototype kit
-{% endblock %}
+{% set pageName = "Data reset" %}
 
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <h1 class="nhsuk-heading-l">Data reset</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <p class="nhsuk-body">The session data has been reset.</p>
 

--- a/lib/prototype-admin/reset.html
+++ b/lib/prototype-admin/reset.html
@@ -1,8 +1,6 @@
 {% extends 'layout.html' %}
 
-{% block pageTitle %}
-  Reset data - NHS prototype kit
-{% endblock %}
+{% set pageName = "Reset data" %}
 
 {% block beforeContent %}
   {{ backLink({
@@ -14,7 +12,7 @@
 {% block content %}
   <div class="nhsuk-grid-row">
     <div class="nhsuk-grid-column-two-thirds">
-      <h1 class="nhsuk-heading-l">Reset data</h1>
+      <h1 class="nhsuk-heading-l">{{ pageName }}</h1>
 
       <p class="nhsuk-body">This will reset all of the data entered in this session.</p>
 

--- a/lib/templates/prototype-kit-template.njk
+++ b/lib/templates/prototype-kit-template.njk
@@ -35,4 +35,6 @@
 {%- from 'textarea/macro.njk' import textarea %}
 {%- from 'warning-callout/macro.njk' import warningCallout %}
 
+{% block pageTitle %}{% if errorsPresent %}Error: {% endif %}{% if pageName %}{{ pageName }} - {% endif %}{{ serviceName }} - NHS{% endblock %}
+
 {% set assetPath = '/nhsuk-frontend/assets' %}

--- a/lib/templates/prototype-kit-template.njk
+++ b/lib/templates/prototype-kit-template.njk
@@ -35,6 +35,6 @@
 {%- from 'textarea/macro.njk' import textarea %}
 {%- from 'warning-callout/macro.njk' import warningCallout %}
 
-{% block pageTitle %}{% if errorsPresent %}Error: {% endif %}{% if pageName %}{{ pageName }} - {% endif %}{{ serviceName }} - NHS{% endblock %}
+{% block pageTitle %}{% if errorsPresent %}Error: {% endif %}{% if pageName %}{{ pageName }} – {% endif %}{{ serviceName }} – NHS{% endblock %}
 
 {% set assetPath = '/nhsuk-frontend/assets' %}

--- a/lib/templates/prototype-kit-template.njk
+++ b/lib/templates/prototype-kit-template.njk
@@ -35,6 +35,10 @@
 {%- from 'textarea/macro.njk' import textarea %}
 {%- from 'warning-callout/macro.njk' import warningCallout %}
 
-{% block pageTitle %}{% if errors == true or (errors | length) %}Error: {% endif %}{% if pageName %}{{ pageName }} – {% endif %}{{ serviceName }} – NHS{% endblock %}
+{% block pageTitle -%}
+  {%- if errors == true or (errors | length) %}Error: {% endif -%}
+  {%- if pageName %}{{ pageName }} – {% endif -%}
+  {{ serviceName }} – NHS
+{%- endblock %}
 
 {% set assetPath = '/nhsuk-frontend/assets' %}

--- a/lib/templates/prototype-kit-template.njk
+++ b/lib/templates/prototype-kit-template.njk
@@ -35,6 +35,6 @@
 {%- from 'textarea/macro.njk' import textarea %}
 {%- from 'warning-callout/macro.njk' import warningCallout %}
 
-{% block pageTitle %}{% if errorsPresent %}Error: {% endif %}{% if pageName %}{{ pageName }} – {% endif %}{{ serviceName }} – NHS{% endblock %}
+{% block pageTitle %}{% if errors == true or (errors | length) %}Error: {% endif %}{% if pageName %}{{ pageName }} – {% endif %}{{ serviceName }} – NHS{% endblock %}
 
 {% set assetPath = '/nhsuk-frontend/assets' %}

--- a/lib/templates/prototype-kit-template.njk
+++ b/lib/templates/prototype-kit-template.njk
@@ -36,7 +36,7 @@
 {%- from 'warning-callout/macro.njk' import warningCallout %}
 
 {% block pageTitle -%}
-  {%- if errors == true or (errors | length) %}Error: {% endif -%}
+  {%- if errors === true or (errors | length) %}Error: {% endif -%}
   {%- if pageName %}{{ pageName }} – {% endif -%}
   {{ serviceName }} – NHS
 {%- endblock %}


### PR DESCRIPTION
This aims to make it easier to set page `<title>s` in accordance with [the guidance in the Service manual](https://service-manual.nhs.uk/design-system/styles/page-template#page-title).

## How it works

Instead of doing this:

```njk
{% block pageTitle %}
  Your address - Register for a GP - NHS
{% end block %}
```

you can now do this:

```
{% set pageName = "Your address %}
```

...and `- {{ serviceName }} - NHS` will be appended automatically.

In addition, you can use another variable to indicate that validation errors are present on the page:

```
{% set errorsPresent = true %}
{% set pageName = "Your address %}
```

...which will generate `Error: Your address - {{ serviceName }} - NHS`.

If a page does not need a separate name from the service name (for example, on the homepage for the service), then `pageName` can be set to `false` or omitted:

```
{% set pageName = false %}
```

...which will generate `{{ serviceName }} - NHS`

This logic can be override by using the `pageTitle` block as before.


Resolves #461. 

See also [Make it easier to set page title](https://github.com/alphagov/govuk-prototype-kit/pull/2030) in the GOV.UK Prototype Kit (resolving [a similar issue](https://github.com/alphagov/govuk-prototype-kit/issues/1975)), which uses the approach (but doesn’t include the `Error: ` prefix).

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
