### PR TITLE
Use an available port if something is running on the default one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### New features
+
+- Use a different port if something is running on the default on ([PR #557](https://github.com/nhsuk/nhsuk-prototype-kit/pull/557))
+
 ### Breaking changes
 
 - The jQuery javascript library is no longer included ([PR #556](https://github.com/nhsuk/nhsuk-prototype-kit/pull/556))

--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ const prototypeAdminRoutes = require('./lib/middleware/prototype-admin-routes');
 const exampleTemplatesRoutes = require('./lib/example_templates_routes');
 
 // Set configuration variables
-const port = parseInt(process.env.PORT || config.port, 10);
+const port = parseInt(process.env.PORT || config.port, 10) || 2000;
 
 // Initialise applications
 const app = express();

--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ const prototypeAdminRoutes = require('./lib/middleware/prototype-admin-routes');
 const exampleTemplatesRoutes = require('./lib/example_templates_routes');
 
 // Set configuration variables
-const port = parseInt(process.env.PORT, 10) || config.port;
+const port = parseInt(process.env.PORT || config.port, 10);
 
 // Initialise applications
 const app = express();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -85,10 +85,10 @@ function startNodemon(done) {
   });
 }
 
-function setAvailablePort(done) {
+async function setAvailablePort() {
   const defaultPort = parseInt(process.env.PORT) || config.port;
 
-  findAvailablePort(function(port) {
+  return findAvailablePort(function(port) {
     process.env.PORT = port
     done()
   }, { defaultPort })

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ const config = require('./app/config');
 const { findAvailablePort } = require('./lib/utils');
 
 // Set configuration variables
-const port = parseInt(process.env.PORT || config.port, 10);
+const port = parseInt(process.env.PORT || config.port, 10) || 2000;
 
 // Delete all the files in /public build directory
 function cleanPublic() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,10 +9,10 @@ const gulpSass = require('gulp-sass')
 const dartSass = require('sass-embedded')
 const nodemon = require('gulp-nodemon');
 const PluginError = require('plugin-error')
-const findAvailablePort = require('./lib/utils/find-available-port');
 
 // Local dependencies
 const config = require('./app/config');
+const findAvailablePort = require('./lib/utils/find-available-port');
 
 // Delete all the files in /public build directory
 function cleanPublic() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,9 +62,15 @@ function compileAssets() {
 
 // Start nodemon
 async function startNodemon(done) {
-  const availablePort = await findAvailablePort(port);
-  if (!availablePort) {
-    done(new PluginError('startNodemon', `Port ${port} in use`));
+  let availablePort
+
+  try {
+    availablePort = await findAvailablePort(port);
+    if (!availablePort) {
+      throw new Error(`Port ${port} in use`);
+    }
+  } catch (error) {
+    done(new PluginError('startNodemon', error));
     return;
   }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -91,7 +91,7 @@ function setAvailablePort(done) {
   findAvailablePort(function(port) {
     process.env.PORT = port
     done()
-  }, {defaultPort: defaultPort})
+  }, { defaultPort })
 }
 
 function reload() {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,7 +12,7 @@ const PluginError = require('plugin-error')
 
 // Local dependencies
 const config = require('./app/config');
-const findAvailablePort = require('./lib/utils/find-available-port');
+const { findAvailablePort } = require('./lib/utils');
 
 // Delete all the files in /public build directory
 function cleanPublic() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,66 +54,6 @@ exports.addCheckedFunction = function (env) { /* eslint-disable-line func-names 
 };
 
 /*
-// Find an available port to run the server on
-exports.findAvailablePort = function (app, callback) {
-  var port = null
-
-  // When the server starts, we store the port in .port.tmp so it tries to restart
-  // on the same port
-  try {
-    port = Number(fs.readFileSync(path.join(__dirname, '/../.port.tmp')))
-  } catch (e) {
-    port = Number(process.env.PORT || config.port)
-  }
-
-  console.log('')
-
-  // Check port is free, else offer to change
-  portScanner.findAPortNotInUse(port, port + 50, '127.0.0.1', function (error, availablePort) {
-    if (error) { throw error }
-    if (port === availablePort) {
-      // Port is free, return it via the callback
-      callback(port)
-    } else {
-      // Port in use - offer to change to available port
-      console.error('ERROR: Port ' + port + ' in use - you may have another prototype running.\n')
-      // Set up prompt settings
-      prompt.colors = false
-      prompt.start()
-      prompt.message = ''
-      prompt.delimiter = ''
-
-      // Ask user if they want to change port
-      prompt.get([{
-        name: 'answer',
-        description: 'Change to an available port? (y/n)',
-        required: true,
-        type: 'string',
-        pattern: /y(es)?|no?/i,
-        message: 'Please enter y or n'
-      }], function (err, result) {
-        if (err) { throw err }
-        if (result.answer.match(/y(es)?/i)) {
-          // User answers yes
-          port = availablePort
-          fs.writeFileSync(path.join(__dirname, '/../.port.tmp'), port)
-          console.log('Changed to port ' + port)
-
-          callback(port)
-        } else {
-          // User answers no - exit
-          console.log('\nYou can set a new default port in server.js, /
-          or by running the server with PORT=XXXX')
-          console.log("\nExit by pressing 'ctrl + c'")
-          process.exit(0)
-        }
-      })
-    }
-  })
-}
-*/
-
-/*
 // Synchronously get the URL for the latest release on GitHub and cache it
 exports.getLatestRelease = function () {
   if (releaseUrl !== null) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,23 +3,25 @@ const { get: getKeypath } = require('lodash');
 const path = require('path');
 const crypto = require('crypto');
 
+const { findAvailablePort } = require('./utils/find-available-port');
+
 // Require core and custom filters, merges to one object
 // and then add the methods to Nunjucks environment
 const coreFilters = require('./core_filters');
 const customFilters = require('../app/filters');
 
-exports.addNunjucksFilters = function (env) { /* eslint-disable-line func-names */
+function addNunjucksFilters(env) {
   const filters = Object.assign(coreFilters(env), customFilters(env));
   Object.keys(filters).forEach((filterName) => {
     env.addFilter(filterName, filters[filterName]);
   });
-};
+}
 
 // Add Nunjucks function called 'checked' to populate radios and checkboxes
 // This function is less useful since NHS Frontend 9.2.0 added an
 // easier way to set checkbox and radio checked items, and may
 // be removed in future.
-exports.addCheckedFunction = function (env) { /* eslint-disable-line func-names */
+function addCheckedFunction(env) {
   env.addGlobal('checked', function (name, value) { /* eslint-disable-line func-names */
     // Check data exists
     if (this.ctx.data === undefined) {
@@ -51,11 +53,11 @@ exports.addCheckedFunction = function (env) { /* eslint-disable-line func-names 
     }
     return checked;
   });
-};
+}
 
 /*
 // Synchronously get the URL for the latest release on GitHub and cache it
-exports.getLatestRelease = function () {
+function getLatestRelease () {
   if (releaseUrl !== null) {
     // Release URL already exists
     console.log('Release url cached:', releaseUrl)
@@ -115,7 +117,7 @@ function renderPath(routePath, res, next) {
   });
 }
 
-exports.matchRoutes = function (req, res, next) { /* eslint-disable-line func-names */
+function matchRoutes(req, res, next) {
   let routePath = req.path;
 
   // Remove the first slash, render won't work with it
@@ -127,11 +129,11 @@ exports.matchRoutes = function (req, res, next) { /* eslint-disable-line func-na
   }
 
   renderPath(routePath, res, next);
-};
+}
 
 // Store data from POST body or GET query in session
 
-const storeData = function (input, data) { /* eslint-disable-line func-names */
+function storeData(input, data) {
   for (const i in input) {
     // any input where the name starts with _ is ignored
     if (i.indexOf('_') === 0) {
@@ -178,7 +180,7 @@ try {
 }
 
 // Middleware - store any data sent in session, and pass it to all views
-exports.autoStoreData = function (req, res, next) { /* eslint-disable-line func-names */
+function autoStoreData(req, res, next) {
   if (!req.session.data) {
     req.session.data = {};
   }
@@ -197,19 +199,18 @@ exports.autoStoreData = function (req, res, next) { /* eslint-disable-line func-
   }
 
   next();
-};
+}
 
 // Set any useful local variables
-exports.setLocals = function (req, res, next) {
-
+function setLocals(req, res, next) {
   // Current page used for the Reset data feature
   res.locals.currentPage = req.originalUrl;
 
   next();
-};
+}
 
 /*
-exports.handleCookies = function (app) {
+function handleCookies (app) {
   return function handleCookies (req, res, next) {
     const COOKIE_NAME = 'seen_cookie_message'
     let cookie = req.cookies[COOKIE_NAME]
@@ -239,4 +240,13 @@ function encryptPassword(password) {
   return hash.digest('hex');
 }
 
-exports.encryptPassword = encryptPassword;
+module.exports = {
+  addCheckedFunction,
+  addNunjucksFilters,
+  autoStoreData,
+  encryptPassword,
+  findAvailablePort,
+  matchRoutes,
+  setLocals,
+  storeData,
+};

--- a/lib/utils/find-available-port.js
+++ b/lib/utils/find-available-port.js
@@ -44,4 +44,6 @@ function findAvailablePort(callback, options = {}) {
   );
 }
 
-module.exports = findAvailablePort;
+module.exports = {
+  findAvailablePort,
+};

--- a/lib/utils/find-available-port.js
+++ b/lib/utils/find-available-port.js
@@ -22,7 +22,7 @@ async function findAvailablePort(startPort = 3000) {
 
   const change = inquirer.confirm({
     message: 'Change to an available port?',
-    default: false
+    default: false,
   });
 
   // Check whether the default port or the default port + 1000

--- a/lib/utils/find-available-port.js
+++ b/lib/utils/find-available-port.js
@@ -1,0 +1,47 @@
+const portScanner = require('portscanner');
+const inquirer = require('@inquirer/prompts');
+
+/**
+ * Find an available port to run a server on. This will check
+ * whether the default port is available and if not, will ask
+ * the user whether to switch to an available port.
+ *
+ * @param {Function} callback - Callback function which will be called with the port selected
+ * @param {Object} options - An options object which can specify a defaultPort (defaults to 3000)
+ */
+function findAvailablePort(callback, options = {}) {
+  const defaultPort = options.defaultPort || 3000;
+
+  // Check whether the default port or the default port + 1000
+  // is free. (1000 is added because that’s what we use for BrowserSync)
+  portScanner.findAPortNotInUse(
+    defaultPort,
+    defaultPort + 1000,
+    '127.0.0.1',
+    async (error, availablePort) => {
+      if (error) {
+        throw error;
+      }
+
+      if (defaultPort === availablePort) {
+        // Default port is free, return it via the callback
+        callback(defaultPort);
+      } else {
+        console.error(`ERROR: Port ${defaultPort} in use - you may have another prototype running.\n`); // eslint-disable-line no-console
+
+        inquirer.confirm({
+          message: 'Change to an available port?',
+        }).then((answeredYes) => {
+          if (answeredYes) {
+            callback(availablePort);
+          } else {
+            // User answered no, exit
+            process.exit(0);
+          }
+        });
+      }
+    },
+  );
+}
+
+module.exports = findAvailablePort;

--- a/lib/utils/find-available-port.js
+++ b/lib/utils/find-available-port.js
@@ -1,4 +1,6 @@
-const portScanner = require('portscanner');
+/* eslint-disable no-console */
+
+const { checkPortStatus, findAPortNotInUse } = require('portscanner');
 const inquirer = require('@inquirer/prompts');
 
 /**
@@ -6,42 +8,29 @@ const inquirer = require('@inquirer/prompts');
  * whether the default port is available and if not, will ask
  * the user whether to switch to an available port.
  *
- * @param {Function} callback - Callback function which will be called with the port selected
- * @param {Object} options - An options object which can specify a defaultPort (defaults to 3000)
+ * @param {number} [startPort] - Find port starting from this port number (optional)
  */
-function findAvailablePort(callback, options = {}) {
-  const defaultPort = options.defaultPort || 3000;
+async function findAvailablePort(startPort = 3000) {
+  const host = '127.0.0.1';
+
+  // Check default port is free
+  if (await checkPortStatus(startPort, host) === 'closed') {
+    return startPort;
+  }
+
+  console.error(`ERROR: Port ${startPort} in use - you may have another prototype running.\n`);
+
+  const change = inquirer.confirm({
+    message: 'Change to an available port?',
+  });
 
   // Check whether the default port or the default port + 1000
   // is free. (1000 is added because that’s what we use for BrowserSync)
-  portScanner.findAPortNotInUse(
-    defaultPort,
-    defaultPort + 1000,
-    '127.0.0.1',
-    async (error, availablePort) => {
-      if (error) {
-        throw error;
-      }
+  if (await change.catch(() => false)) {
+    return findAPortNotInUse([startPort, startPort + 1000], host);
+  }
 
-      if (defaultPort === availablePort) {
-        // Default port is free, return it via the callback
-        callback(defaultPort);
-      } else {
-        console.error(`ERROR: Port ${defaultPort} in use - you may have another prototype running.\n`); // eslint-disable-line no-console
-
-        inquirer.confirm({
-          message: 'Change to an available port?',
-        }).then((answeredYes) => {
-          if (answeredYes) {
-            callback(availablePort);
-          } else {
-            // User answered no, exit
-            process.exit(0);
-          }
-        });
-      }
-    },
-  );
+  return undefined;
 }
 
 module.exports = {

--- a/lib/utils/find-available-port.js
+++ b/lib/utils/find-available-port.js
@@ -22,6 +22,7 @@ async function findAvailablePort(startPort = 3000) {
 
   const change = inquirer.confirm({
     message: 'Change to an available port?',
+    default: false
   });
 
   // Check whether the default port or the default port + 1000

--- a/lib/utils/find-available-port.js
+++ b/lib/utils/find-available-port.js
@@ -28,7 +28,7 @@ async function findAvailablePort(startPort = 3000) {
   // Check whether the default port or the default port + 1000
   // is free. (1000 is added because that’s what we use for BrowserSync)
   if (await change.catch(() => false)) {
-    return findAPortNotInUse([startPort, startPort + 1000], host);
+    return findAPortNotInUse(startPort, startPort + 1000, host);
   }
 
   return undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       "dependencies": {
         "@babel/core": "^7.26.0",
         "@babel/preset-env": "^7.27.2",
+        "@inquirer/prompts": "^7.5.3",
         "body-parser": "^2.2.0",
         "browser-sync": "^3.0.4",
         "client-sessions": "^0.8.0",
@@ -31,6 +32,7 @@
         "nunjucks": "^3.2.4",
         "path": "^0.12.7",
         "plugin-error": "^2.0.1",
+        "portscanner": "^2.2.0",
         "sass-embedded": "1.77.5"
       },
       "devDependencies": {
@@ -1883,6 +1885,390 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.2.tgz",
+      "integrity": "sha512-E+KExNurKcUJJdxmjglTl141EwxWyAHplvsYJQgSwXf8qiNWkTxTuCCqmhFEmbIXd4zLaGMfQFJ6WrZ7fSeV3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.16",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.16.tgz",
+      "integrity": "sha512-j1a5VstaK5KQy8Mu8cHmuQvN1Zc62TbLhjJxwHvKPPKEoowSF6h/0UdOpA9DNdWZ+9Inq73+puRq1df6OJ8Sag==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.2.0.tgz",
+      "integrity": "sha512-NyDSjPqhSvpZEMZrLCYUquWNl+XC/moEcVFqS55IEYIYsY0a1cUCevSqk7ctOlnm/RaSBU5psFryNlxcmGrjaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.18.tgz",
+      "integrity": "sha512-yeQN3AXjCm7+Hmq5L6Dm2wEDeBRdAZuyZ4I7tWSSanbxDzqM0KqzoDbKM7p4ebllAYdoQuPJS6N71/3L281i6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/external-editor": "^1.0.1",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.18.tgz",
+      "integrity": "sha512-xUjteYtavH7HwDMzq4Cn2X4Qsh5NozoDHCJTdoXg9HfZ4w3R6mxV1B9tL7DGJX2eq/zqtsFjhm0/RJIMGlh3ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.2.tgz",
+      "integrity": "sha512-hqOvBZj/MhQCpHUuD3MVq18SSoDNHy7wEnQ8mtvs71K8OPZVXJinOzcvQna33dNYLYE4LkA9BlhAhK6MJcsVbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.18.tgz",
+      "integrity": "sha512-7exgBm52WXZRczsydCVftozFTrrwbG5ySE0GqUd2zLNSBXyIucs2Wnm7ZKLe/aUu6NUg9dg7Q80QIHCdZJiY4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.18.tgz",
+      "integrity": "sha512-zXvzAGxPQTNk/SbT3carAD4Iqi6A2JS2qtcqQjsL22uvD+JfQzUrDEtPjLL7PLn8zlSNyPdY02IiQjzoL9TStA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.4.tgz",
+      "integrity": "sha512-MuxVZ1en1g5oGamXV3DWP89GEkdD54alcfhHd7InUW5BifAdKQEK9SLFa/5hlWbvuhMPlobF0WAx7Okq988Jxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.2.2",
+        "@inquirer/confirm": "^5.1.16",
+        "@inquirer/editor": "^4.2.18",
+        "@inquirer/expand": "^4.0.18",
+        "@inquirer/input": "^4.2.2",
+        "@inquirer/number": "^3.0.18",
+        "@inquirer/password": "^4.0.18",
+        "@inquirer/rawlist": "^4.1.6",
+        "@inquirer/search": "^3.1.1",
+        "@inquirer/select": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.6.tgz",
+      "integrity": "sha512-KOZqa3QNr3f0pMnufzL7K+nweFFCCBs6LCXZzXDrVGTyssjLeudn5ySktZYv1XiSqobyHRYYK0c6QsOxJEhXKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.1.tgz",
+      "integrity": "sha512-TkMUY+A2p2EYVY3GCTItYGvqT6LiLzHBnqsU1rJbrpXUijFfM6zvUx0R4civofVwFCmJZcKqOVwwWAjplKkhxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.2.tgz",
+      "integrity": "sha512-nwous24r31M+WyDEHV+qckXkepvihxhnyIaod2MG7eCE6G0Zm/HUF6jgN8GXgf4U7AU6SLseKdanY195cwvU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.2.0",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3116,7 +3502,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
       "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "type-fest": "^0.21.3"
@@ -4243,6 +4628,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/chardet": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
+      "license": "MIT"
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4323,6 +4714,15 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/client-sessions": {
@@ -10394,6 +10794,15 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/nan": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
@@ -13669,7 +14078,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
@@ -14634,6 +15042,18 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@babel/core": "^7.26.0",
     "@babel/preset-env": "^7.27.2",
+    "@inquirer/prompts": "^7.5.3",
     "body-parser": "^2.2.0",
     "browser-sync": "^3.0.4",
     "client-sessions": "^0.8.0",
@@ -39,6 +40,7 @@
     "nunjucks": "^3.2.4",
     "path": "^0.12.7",
     "plugin-error": "^2.0.1",
+    "portscanner": "^2.2.0",
     "sass-embedded": "1.77.5"
   },
   "devDependencies": {


### PR DESCRIPTION
This checks whether the port (specified in either `config.js` or as a `PORT` environment variable) is currently available, and if not, asks the user whether to pick a new one. If they answer yes, an available port is selected instead.

This allows multiple prototypes to be more easily run at the same time.

Inspired by from [`findAvailablePort`](https://github.com/alphagov/govuk-prototype-kit/blob/main/lib/utils/index.js#L95-L131) in the GOVUK Prototype Kit but switching out [`inquirer`](https://www.npmjs.com/package/inquirer) for the more recent [`@inquirer/prompts`](https://www.npmjs.com/package/@inquirer/prompts).

I’m only using it from the `gulpfile.js` rather than in `app.js` as it should only be used in local development mode - if you’re running `npm start` on a server like Heroku then it’s better to immediately error if the specified PORT is already in use.

Fixes #114

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
