### PR TITLE
Configure Sass load paths, Babel and Browserslist

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,17 @@
 {
-  "presets": ["@babel/preset-env"]
+  "browserslistEnv": "javascripts",
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "bugfixes": true,
+        "loose": true
+      }
+    ]
+  ],
+  "env": {
+    "test": {
+      "browserslistEnv": "node"
+    }
+  }
 }

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,16 @@
+[javascripts]
+supports es6-module
+
+[stylesheets]
+> 0.1% in GB and not dead
+last 6 Chrome versions
+last 6 Firefox versions
+last 6 Edge versions
+last 2 Samsung versions
+Firefox ESR
+Safari >= 11
+iOS >= 11
+IE 11
+
+[node]
+node 20

--- a/app/assets/sass/main.scss
+++ b/app/assets/sass/main.scss
@@ -1,4 +1,4 @@
 // Import NHS.UK frontend library
-@import "node_modules/nhsuk-frontend/dist/nhsuk";
+@import "nhsuk-frontend/dist/nhsuk";
 
 // Add your custom CSS/Sass styles below.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,9 +25,14 @@ const sass = gulpSass(dartSass)
 // Compile SASS to CSS
 function compileStyles(done) {
   return gulp
-    .src(['app/assets/sass/**/*.scss'])
+    .src(['app/assets/sass/**/*.scss'], {
+      sourcemaps: true
+    })
     .pipe(
-      sass().on('error', (error) => {
+      sass({
+        sourceMap: true,
+        sourceMapIncludeSources: true
+      }).on('error', (error) => {
         done(
           new PluginError('compileCSS', error.messageFormatted, {
             showProperties: false
@@ -35,15 +40,25 @@ function compileStyles(done) {
         )
       })
     )
-    .pipe(gulp.dest('public/css'))
+    .pipe(
+      gulp.dest('public/css', {
+        sourcemaps: '.'
+      })
+    )
 }
 
 // Compile JavaScript (with ES6 support)
 function compileScripts() {
   return gulp
-    .src(['app/assets/javascript/**/*.js'])
+    .src(['app/assets/javascript/**/*.js'], {
+      sourcemaps: true
+    })
     .pipe(babel())
-    .pipe(gulp.dest('public/js'))
+    .pipe(
+      gulp.dest('public/js', {
+        sourcemaps: '.'
+      })
+    )
 }
 
 // Compile assets

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,6 +20,7 @@ function cleanPublic() {
   return gulp.src('public', { allowEmpty: true }).pipe(clean())
 }
 
+// Set Sass compiler
 const sass = gulpSass(dartSass)
 
 // Compile SASS to CSS
@@ -30,6 +31,7 @@ function compileStyles(done) {
     })
     .pipe(
       sass({
+        loadPaths: ['node_modules'],
         sourceMap: true,
         sourceMapIncludeSources: true
       }).on('error', (error) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "gulp-clean-css": "^4.3.0",
         "gulp-nodemon": "^2.5.0",
         "gulp-rename": "^2.1.0",
-        "gulp-sass": "^5.1.0",
+        "gulp-sass": "^6.0.1",
         "lodash": "^4.17.21",
         "nhsuk-frontend": "^10.0.0",
         "nunjucks": "^3.2.4",
@@ -9231,9 +9231,10 @@
       }
     },
     "node_modules/gulp-sass": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-5.1.0.tgz",
-      "integrity": "sha512-7VT0uaF+VZCmkNBglfe1b34bxn/AfcssquLKVDYnCDJ3xNBaW7cUuI3p3BQmoKcoKFrs9jdzUxyb+u+NGfL4OQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-6.0.1.tgz",
+      "integrity": "sha512-4wonidxB8lGPHvahelpGavUBJAuERSl+OIVxPCyQthK4lSJhZ/u3/qjFcyAtnMIXDl6fXTn34H4BXsN7gt54kQ==",
+      "license": "MIT",
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "picocolors": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "gulp-clean-css": "^4.3.0",
     "gulp-nodemon": "^2.5.0",
     "gulp-rename": "^2.1.0",
-    "gulp-sass": "^5.1.0",
+    "gulp-sass": "^6.0.1",
     "lodash": "^4.17.21",
     "nhsuk-frontend": "^10.0.0",
     "nunjucks": "^3.2.4",
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.41.0",
     "@typescript-eslint/parser": "^8.41.0",
+    "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-standard": "^17.1.0",
     "eslint-plugin-import": "^2.32.0",
@@ -57,7 +58,6 @@
     "eslint-plugin-jsdoc": "^54.1.1",
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.6.0",
-    "eslint": "^8.57.1",
     "jest": "^30.0.5",
     "prettier": "^3.6.2"
   },


### PR DESCRIPTION
## Description

From the NHS.UK frontend v10 changes this PR adds Sass `loadPaths` to support:

```patch
  // Import NHS.UK frontend library
- @import "node_modules/nhsuk-frontend/dist/nhsuk";
+ @import "nhsuk-frontend/dist/nhsuk";
```

I've also updated the Babel config to ensure tranforms for older browser are skipped

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
