### PR TITLE
Improve Sass error handling when watching for changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix NHS.UK frontend allowed paths on password page
 - Fix reset session data route via GET request
+- Improve Sass error handling when watching for changes
 - Prevent unnecessary console logging from dotenv
 - Preserve defaults when merging filters or session options
 - Configure Nodemon to ignore browser JavaScript

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ function cleanPublic() {
 const sass = gulpSass(dartSass)
 
 // Compile SASS to CSS
-function compileStyles(done) {
+function compileStyles() {
   return gulp
     .src(['app/assets/sass/**/*.scss'], {
       sourcemaps: true
@@ -35,11 +35,9 @@ function compileStyles(done) {
         sourceMap: true,
         sourceMapIncludeSources: true
       }).on('error', (error) => {
-        done(
-          new PluginError('compileCSS', error.messageFormatted, {
-            showProperties: false
-          })
-        )
+        throw new PluginError('compileCSS', error.messageFormatted, {
+          showProperties: false
+        })
       })
     )
     .pipe(


### PR DESCRIPTION
## Description

This PR fixes an existing issue where the Sass `.on('error')` handler ends the `gulp watch` session

The issue cannot be reproduced on this repo and might be unique to Node.js 22, but it's affecting [NHSDigital/manage-breast-screening-prototype](https://github.com/NHSDigital/manage-breast-screening-prototype) where `gulp watch` is interrupted when Sass errors are thrown

The kits error handling code still runs but is followed by a [(deprecated) Node.js domain](https://nodejs.org/api/domain.html) error:

```console
node:internal/process/task_queues:105
    runMicrotasks();
    ^
```

```console
Emitted 'error' event on Domain instance at:
    at Transform.emit (node:domain:540:12)
    at WritableState.afterDestroy (/path/to/project/node_modules/streamx/index.js:514:19)
    at Transform._destroy (/path/to/project/node_modules/streamx/index.js:650:5)
    at WritableState.updateNonPrimary (/path/to/project/node_modules/streamx/index.js:213:16)
    at WritableState.update (/path/to/project/node_modules/streamx/index.js:195:72)
    at WritableState.updateWriteNT (/path/to/project/node_modules/streamx/index.js:564:10)
    at node:internal/process/task_queues:151:7
    at AsyncResource.runInAsyncScope (node:async_hooks:214:14)
    at AsyncResource.runMicrotask (node:internal/process/task_queues:148:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
```

Maybe another Gulp plugin is causing it, which brings back [gulp-plumber](https://www.npmjs.com/package/gulp-plumber) memories

Switching to `throw error` instead of `done(error)` defers to Gulp before `.emit()` has chance to run

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
