### PR TITLE
Fix NHS.UK frontend allowed paths on password page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS prototype kit Changelog
 
+## Unreleased
+
+:wrench: **Fixes**
+
+- Fix NHS.UK frontend allowed paths on password page
+
 ## 7.0.0 - 27 August 2025
 
 ### New features

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -52,7 +52,10 @@ function showNoPasswordError(res) {
 function authentication(req, res, next) {
   if (!process.env.PROTOTYPE_PASSWORD) {
     showNoPasswordError(res)
-  } else if (allowedPathsWhenUnauthenticated.includes(req.path)) {
+  } else if (
+    req.path.startsWith('/nhsuk-frontend/assets/') ||
+    allowedPathsWhenUnauthenticated.includes(req.path)
+  ) {
     next()
   } else if (req.cookies.authentication === encryptedPassword) {
     next()

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -5,7 +5,7 @@ const { encryptPassword } = require('../utils')
 const allowedPathsWhenUnauthenticated = [
   '/prototype-admin/password',
   '/css/main.css',
-  '/nhsuk-frontend/nhsuk.min.js',
+  '/nhsuk-frontend/nhsuk-frontend.min.js',
   '/js/auto-store-data.js',
   '/js/main.js'
 ]

--- a/lib/middleware/authentication.js
+++ b/lib/middleware/authentication.js
@@ -5,9 +5,13 @@ const { encryptPassword } = require('../utils')
 const allowedPathsWhenUnauthenticated = [
   '/prototype-admin/password',
   '/css/main.css',
+  '/css/main.css.map',
   '/nhsuk-frontend/nhsuk-frontend.min.js',
+  '/nhsuk-frontend/nhsuk-frontend.min.js.map',
   '/js/auto-store-data.js',
-  '/js/main.js'
+  '/js/auto-store-data.js.map',
+  '/js/main.js',
+  '/js/main.js.map'
 ]
 
 const encryptedPassword = encryptPassword(process.env.PROTOTYPE_PASSWORD)


### PR DESCRIPTION
## Description

This PR fixes the password page allowed paths to include:

1. NHS.UK frontend JavaScript via ~`nhsuk.min.js`~ `nhsuk-frontend.min.js`
2. NHS.UK frontend asset requests to app icons, **manifest.json** etc
3. Source maps for existing assets (when developer tools are open)

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
