### PR TITLE
Preserve defaults when merging filters or session options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix NHS.UK frontend allowed paths on password page
 - Fix reset session data route via GET request
 - Prevent unnecessary console logging from dotenv
+- Preserve defaults when merging filters or session options
 - Configure Nodemon to ignore browser JavaScript
 - Exclude app code from linters by default
 - Adds an .editorconfig file

--- a/app.js
+++ b/app.js
@@ -101,23 +101,21 @@ if (process.env.NODE_ENV === 'production') {
 // Support session data in cookie or memory
 if (useCookieSessionStore === 'true') {
   app.use(
-    sessionInCookie(
-      Object.assign(sessionOptions, {
-        cookieName: sessionName,
-        proxy: true,
-        requestKey: 'session'
-      })
-    )
+    sessionInCookie({
+      ...sessionOptions,
+      cookieName: sessionName,
+      proxy: true,
+      requestKey: 'session'
+    })
   )
 } else {
   app.use(
-    sessionInMemory(
-      Object.assign(sessionOptions, {
-        name: sessionName,
-        resave: false,
-        saveUninitialized: false
-      })
-    )
+    sessionInMemory({
+      ...sessionOptions,
+      name: sessionName,
+      resave: false,
+      saveUninitialized: false
+    })
   )
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,10 +16,14 @@ const { findAvailablePort } = require('./utils/find-available-port')
  * @param {Environment} env
  */
 function addNunjucksFilters(env) {
-  const filters = Object.assign(coreFilters(env), customFilters(env))
-  Object.keys(filters).forEach((filterName) => {
-    env.addFilter(filterName, filters[filterName])
-  })
+  const filters = {
+    ...coreFilters(env),
+    ...customFilters(env)
+  }
+
+  for (const [name, filter] of Object.entries(filters)) {
+    env.addFilter(name, filter)
+  }
 }
 
 /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,11 +9,8 @@ const customFilters = require('../app/filters')
 const coreFilters = require('./core_filters')
 const { findAvailablePort } = require('./utils/find-available-port')
 
-// Require core and custom filters, merges to one object
-// and then add the methods to Nunjucks environment
-
 /**
- * Require core and custom filters, merges to one object
+ * Merge the core and custom filters into one object
  * and then add the methods to Nunjucks environment
  *
  * @param {Environment} env


### PR DESCRIPTION
## Description

Mainly fixed a duplicate comment (my fault) but also noticed we modify existing objects when merging:

```patch
- Object.assign(sessionOptions, {
+ Object.assign({}, sessionOptions, {
```

Not a necessary change, happy to drop that commit

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
