### PR TITLE
Restore dotenv `quiet: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - Fix NHS.UK frontend allowed paths on password page
+- Prevent unnecessary console logging from dotenv
 
 ## 7.0.0 - 27 August 2025
 

--- a/app.js
+++ b/app.js
@@ -18,7 +18,9 @@ const sessionInMemory = require('express-session')
 const nunjucks = require('nunjucks')
 
 // Run before other code to make sure variables from .env are available
-dotenv.config()
+dotenv.config({
+  quiet: true
+})
 
 // Local dependencies
 const config = require('./app/config')


### PR DESCRIPTION
## Description

This PR reverts the new default `{ quiet: false }` in https://github.com/nhsuk/nhsuk-prototype-kit/pull/576 which logs this promotion at startup:

```console
[dotenv@17.2.1] injecting env (0) from .env -- tip: 📡 observe env with Radar: https://dotenvx.com/radar
```

Fixes https://github.com/nhsuk/nhsuk-prototype-kit/issues/597

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
