### PR TITLE
Configure Nodemon to ignore browser JavaScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix NHS.UK frontend allowed paths on password page
 - Prevent unnecessary console logging from dotenv
+- Configure Nodemon to ignore browser JavaScript
 
 ## 7.0.0 - 27 August 2025
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,7 @@ async function startNodemon(done) {
   const server = nodemon({
     script: 'app.js',
     stdout: true,
-    ext: 'js',
+    ext: 'js json',
     watch: ['.env', 'app.js', 'app', 'lib'],
     ignore: ['app/assets', '**.test.*'],
     quiet: false

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,6 +98,8 @@ async function startNodemon(done) {
     script: 'app.js',
     stdout: true,
     ext: 'js',
+    watch: ['.env', 'app.js', 'app', 'lib'],
+    ignore: ['app/assets', '**.test.*'],
     quiet: false
   })
 


### PR DESCRIPTION
## Description

Fixes https://github.com/nhsuk/nhsuk-prototype-kit/issues/598 and additionally watches JSON files by default

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
