### PR TITLE
Fix reset session data route via GET request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 :wrench: **Fixes**
 
 - Fix NHS.UK frontend allowed paths on password page
+- Fix reset session data route via GET request
 - Prevent unnecessary console logging from dotenv
 
 ## 7.0.0 - 27 August 2025

--- a/lib/middleware/prototype-admin-routes.js
+++ b/lib/middleware/prototype-admin-routes.js
@@ -44,10 +44,12 @@ router.get('/reset', (req, res) => {
 })
 
 router.all('/reset-session-data', (req, res) => {
-  const returnPage =
-    req.body.returnPage && req.body.returnPage.startsWith('/')
-      ? req.body.returnPage // Local paths only
-      : '/'
+  let { returnPage } = req.body ?? {}
+
+  // Allow local paths only
+  if (!returnPage?.startsWith('/')) {
+    returnPage = '/'
+  }
 
   req.session.data = {}
 

--- a/lib/middleware/prototype-admin-routes.js
+++ b/lib/middleware/prototype-admin-routes.js
@@ -37,14 +37,20 @@ router.post('/password', (req, res) => {
 })
 
 router.get('/reset', (req, res) => {
-  const returnPage = req.query.returnPage || '/'
+  let { returnPage } = req.query
+
+  // Allow local paths only
+  if (!returnPage?.startsWith('/')) {
+    returnPage = '/'
+  }
+
   res.render('reset', {
     returnPage
   })
 })
 
 router.all('/reset-session-data', (req, res) => {
-  let { returnPage } = req.body ?? {}
+  let { returnPage } = req.body ?? req.query
 
   // Allow local paths only
   if (!returnPage?.startsWith('/')) {


### PR DESCRIPTION
## Description

Fixes https://github.com/nhsuk/nhsuk-prototype-kit/issues/603 and adds local path checks to `/reset` not just `/reset-session-data`

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
