### PR TITLE
Open preview in a new browser tab instead of an preview

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
       // 'silent' (does nothing)
       // 'openBrowser' (opens the prototype URL in a browser window/tab)
       // 'openPrview' (opens the codespaces preview window to present the running prototype to the user)
-      "onAutoForward": "openPreview"
+      "onAutoForward": "openBrowser"
     }
   },
   // forward the port for the browersync process


### PR DESCRIPTION
This defaults the prototype to running in a new browser tab, instead of a tab within Codespaces itself.

The advantage to this is that if you refresh it using Control-R, it'll only refresh the browser tab and not the whole of codespaces. It also makes it a bit easier to test the responsiveness by resizing the window.

The downside is that depending on your browser settings you might get a popup warning first:

<img width="1040" height="555" alt="Screenshot 2025-09-10 at 10 30 03" src="https://github.com/user-attachments/assets/5b56971b-9995-4655-9297-1b5110484e66" />