### PR TITLE
Fix Browsersync in GitHub Codespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # NHS prototype kit Changelog
 
+## Unreleased
+
+:wrench: **Fixes**
+
+- Fix Browsersync in Codespaces
+
 ## 7.0.1 - 5 September 2025
 
 :wrench: **Fixes**

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+const { join } = require('node:path')
+
 // External dependencies
 const browserSync = require('browser-sync')
 const gulp = require('gulp')
@@ -5,6 +7,7 @@ const babel = require('gulp-babel')
 const clean = require('gulp-clean')
 const nodemon = require('gulp-nodemon')
 const gulpSass = require('gulp-sass')
+const { createProxyMiddleware } = require('http-proxy-middleware')
 const PluginError = require('plugin-error')
 const dartSass = require('sass-embedded')
 
@@ -127,14 +130,24 @@ async function startBrowserSync(done) {
 
   browserSync.init(
     {
-      proxy: `localhost:${proxyPort}`,
       port: proxyPort + 1000,
       ui: false,
       files: ['app/views/**/*.*', 'lib/example-templates/**/*.*'],
       ghostMode: false,
       open: false,
       notify: true,
-      watch: true
+      watch: true,
+
+      // Proxy to Node.js server
+      middleware: createProxyMiddleware({
+        changeOrigin: true,
+        target: `http://localhost:${proxyPort}`
+      }),
+
+      // Serve static assets
+      server: {
+        baseDir: join(__dirname, 'public')
+      }
     },
     done
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "gulp-nodemon": "^2.5.0",
         "gulp-rename": "^2.1.0",
         "gulp-sass": "^6.0.1",
+        "http-proxy-middleware": "^3.0.5",
         "lodash": "^4.17.21",
         "nhsuk-frontend": "^10.0.0",
         "nunjucks": "^3.2.4",
@@ -3173,6 +3174,15 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/http-proxy": {
+      "version": "1.17.16",
+      "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.16.tgz",
+      "integrity": "sha512-sdWoUajOB1cd0A8cRRQ1cfyWNbmFKLAqBB89Y8x5iYyG/mkJHc0YUH8pdWBy2omi9qtCpiIgGjuwO0dQST2l5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.6",
@@ -9485,6 +9495,55 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/http-proxy-middleware": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
+        "is-glob": "^4.0.3",
+        "is-plain-object": "^5.0.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/http-proxy-middleware/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "gulp-nodemon": "^2.5.0",
     "gulp-rename": "^2.1.0",
     "gulp-sass": "^6.0.1",
+    "http-proxy-middleware": "^3.0.5",
     "lodash": "^4.17.21",
     "nhsuk-frontend": "^10.0.0",
     "nunjucks": "^3.2.4",


### PR DESCRIPTION
## Description

This PR makes sure Browsersync works in GitHub Codespaces to close https://github.com/nhsuk/nhsuk-prototype-kit/issues/622

Since Browsersync prepends its own **browser-sync-client.js** script using [**templates/connector.tmpl**](https://github.com/BrowserSync/browser-sync/blob/master/packages/browser-sync/templates/connector.tmpl) we can follow the URL building code in [**lib/connect-utils.js**](https://github.com/BrowserSync/browser-sync/blob/dc74bc0a6bcbe70eea5f2f94b524b2902436efb1/packages/browser-sync/lib/connect-utils.js#L176-L186) to make sure we avoid custom port numbers in GitHub Codespaces.

For example:

### ❌ Browsersync as a proxy
When configured via [`proxy`](https://browsersync.io/docs/options#option-proxy) the Browsersync socket request includes the port:

```js
___browserSync___.socketUrl = 'http://' + location.hostname + ':3000/browser-sync';
```

### ✅ Browsersync as a server
When configured via [`server`](https://browsersync.io/docs/options#option-server) the Browsersync socket request uses the same host as the application:
```js
___browserSync___.socketUrl = '' + location.host + '/browser-sync';
```

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
