### PR TITLE
Turn on word wrapping by default in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,8 @@
     "vscode": {
       // editor settings
       "settings": {
+        // Turn on word wrapping by default
+        "editor.wordWrap": "on",
         // uncomment the following lines to hide files not needed to update content
         // "files.exclude": {
         //   "{docs,lib,linters,middleware,node_modules,public,tests,NHS111.Shared.Frontend}/": true,


### PR DESCRIPTION
This otherwise defaults to off, which means horizontal scrolling.