### PR TITLE
Turn off minimap by default in Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -33,6 +33,8 @@
     "vscode": {
       // editor settings
       "settings": {
+        // Turn off minimap by default, as it's distracting for new users
+        "editor.minimap.enabled": false,
         // uncomment the following lines to hide files not needed to update content
         // "files.exclude": {
         //   "{docs,lib,linters,middleware,node_modules,public,tests,NHS111.Shared.Frontend}/": true,


### PR DESCRIPTION
I think the [Minimap](https://code.visualstudio.com/docs/getstarted/userinterface#_minimap) feature is probably a bit distracting for new users?

(It can still be turned on again in the interface)