### PR TITLE
Add filter for formatting NHS numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-:wrench: **Fixes**
+### :new: **New features**
+
+- Add a filter for formatting NHS numbers with spaces ([PR ](https://github.com/nhsuk/nhsuk-prototype-kit/pull/663))
+
+### :wrench: **Fixes**
 
 - Fix Browsersync in Codespaces
 - Fix nested query strings not saving correctly ([PR #645](https://github.com/nhsuk/nhsuk-prototype-kit/pull/645), Fixes [#644](https://github.com/nhsuk/nhsuk-prototype-kit/issues/644))

--- a/lib/core_filters.js
+++ b/lib/core_filters.js
@@ -12,6 +12,8 @@ module.exports = function (env) {
    */
   const filters = {}
 
+  filters.formatNhsNumber = require('./filters/format-nhs-number')
+
   /**
    * Logs an object in the template to the console in the browser.
    *

--- a/lib/filters/format-nhs-number.js
+++ b/lib/filters/format-nhs-number.js
@@ -3,7 +3,8 @@
  *
  * The format is 3 3 4: 2 groups of 3 digits followed by 4 digits.
  *
- * For example, "4857773456" becomes "485 777 3456". (This is an example or test number.)
+ * For example, "4857773456" becomes "485 777 3456".
+ * (This is an example or test number.)
  *
  * This number format makes it easier for people and assistive technologies
  * to read. It also makes it less likely that people will make mistakes.

--- a/lib/filters/format-nhs-number.js
+++ b/lib/filters/format-nhs-number.js
@@ -1,6 +1,8 @@
 /**
  * Display an NHS number formatted with spaces
  *
+ * The format is 3 3 4: 2 groups of 3 digits followed by 4 digits.
+ *
  * This number format makes it easier for people and assistive technologies
  * to read. It also makes it less likely that people will make mistakes.
  *

--- a/lib/filters/format-nhs-number.js
+++ b/lib/filters/format-nhs-number.js
@@ -3,6 +3,8 @@
  *
  * The format is 3 3 4: 2 groups of 3 digits followed by 4 digits.
  *
+ * For example, "485 777 3456". (This is an example or test number.)
+ *
  * This number format makes it easier for people and assistive technologies
  * to read. It also makes it less likely that people will make mistakes.
  *

--- a/lib/filters/format-nhs-number.js
+++ b/lib/filters/format-nhs-number.js
@@ -3,7 +3,7 @@
  *
  * The format is 3 3 4: 2 groups of 3 digits followed by 4 digits.
  *
- * For example, "485 777 3456". (This is an example or test number.)
+ * For example, "4857773456" becomes "485 777 3456". (This is an example or test number.)
  *
  * This number format makes it easier for people and assistive technologies
  * to read. It also makes it less likely that people will make mistakes.

--- a/lib/filters/format-nhs-number.js
+++ b/lib/filters/format-nhs-number.js
@@ -3,7 +3,7 @@
  *
  * The format is 3 3 4: 2 groups of 3 digits followed by 4 digits.
  *
- * For example, "4857773456" becomes "485 777 3456".
+ * For example, "9991234567" becomes "999 123 4567".
  * (This is an example or test number.)
  *
  * This number format makes it easier for people and assistive technologies

--- a/lib/filters/format-nhs-number.js
+++ b/lib/filters/format-nhs-number.js
@@ -1,0 +1,24 @@
+/**
+ * Display an NHS number formatted with spaces
+ *
+ * This number format makes it easier for people and assistive technologies
+ * to read. It also makes it less likely that people will make mistakes.
+ *
+ * See https://service-manual.nhs.uk/content/a-to-z-of-nhs-health-writing#nhs-number
+ *
+ * @param {string} nhsNumber - the NHS number to format
+ * @returns {string} Formatted NHS number
+ */
+function formatNhsNumber(nhsNumber) {
+  const digitsOnly = String(nhsNumber).replace(/[^0-9]/g, '')
+
+  if (digitsOnly.length != 10) {
+    return nhsNumber
+  }
+
+  let formatted = `${digitsOnly.substring(0, 3)} ${digitsOnly.substring(3, 6)} ${digitsOnly.substring(6, 10)}`
+
+  return formatted
+}
+
+module.exports = formatNhsNumber

--- a/tests/lib/filters/format-nhs-number.test.js
+++ b/tests/lib/filters/format-nhs-number.test.js
@@ -1,0 +1,29 @@
+const formatNhsNumber = require('../../../lib/filters/format-nhs-number')
+
+test('formatNhsNumber with a string of 10 digits', () => {
+  expect(formatNhsNumber('9991231230')).toBe('999 123 1230')
+})
+
+test('formatNhsNumber with 10 digits as a number', () => {
+  expect(formatNhsNumber(9991231230)).toBe('999 123 1230')
+})
+
+test('formatNhsNumber with a string of 10 digits containing spaces', () => {
+  expect(formatNhsNumber('9 991 23 123 0  ')).toBe('999 123 1230')
+})
+
+test('formatNhsNumber with a string of 10 digits and other characters', () => {
+  expect(formatNhsNumber('999-123-123-0')).toBe('999 123 1230')
+})
+
+test('formatNhsNumber with a string of less than 10 digits', () => {
+  expect(formatNhsNumber('123456789')).toBe('123456789')
+})
+
+test('formatNhsNumber with a string of more than 10 digits', () => {
+  expect(formatNhsNumber('12345678901')).toBe('12345678901')
+})
+
+test('formatNhsNumber with null', () => {
+  expect(formatNhsNumber(null)).toBeNull()
+})

--- a/tests/lib/filters/format-nhs-number.test.js
+++ b/tests/lib/filters/format-nhs-number.test.js
@@ -17,11 +17,11 @@ test('formatNhsNumber with a string of 10 digits and other characters', () => {
 })
 
 test('formatNhsNumber with a string of less than 10 digits', () => {
-  expect(formatNhsNumber('123456789')).toBe('123456789')
+  expect(formatNhsNumber('99912345')).toBe('99912345')
 })
 
 test('formatNhsNumber with a string of more than 10 digits', () => {
-  expect(formatNhsNumber('12345678901')).toBe('12345678901')
+  expect(formatNhsNumber('9991234567123')).toBe('9991234567123')
 })
 
 test('formatNhsNumber with null', () => {


### PR DESCRIPTION
This adds a built-in filter for formatting NHS numbers using spaces.

The number format is:

> The format is 3 3 4: 2 groups of 3 digits followed by 4 digits.

This number format makes it easier for people and assistive technologies to read. It also makes it less likely that people will make mistakes.

See https://service-manual.nhs.uk/content/a-to-z-of-nhs-health-writing#nhs-number
 
Resolves #654