### PR TITLE
Add Dependabot groups with monthly checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    ignore:
-      # SASS updates will be done manually in sync with
-      # NHS Frontend to avoid deprecation warnings.
-      - dependency-name: 'sass-embedded'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,8 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'monthly'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,59 @@
 version: 2
+
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
+  # Update npm packages
+  - package-ecosystem: npm
+    directory: /
+
+    # Group packages into shared PR
+    groups:
+      application:
+        patterns:
+          - 'body-parser'
+          - 'client-sessions'
+          - 'cookie-parser'
+          - 'dotenv'
+          - 'express'
+          - 'express-*'
+          - 'lodash'
+          - 'nhsuk-frontend'
+          - 'nunjucks'
+
+      build:
+        patterns:
+          - '@babel/*'
+          - 'sass-embedded'
+
+      lint:
+        patterns:
+          - '@typescript-eslint/*'
+          - 'eslint'
+          - 'eslint-*'
+          - 'prettier'
+
+      test:
+        patterns:
+          - 'jest'
+          - 'jest-*'
+
+      tools:
+        patterns:
+          - '@inquirer/prompts'
+          - 'browser-sync'
+          - 'gulp'
+          - 'gulp-*'
+          - 'http-proxy-middleware'
+          - 'plugin-error'
+          - 'portscanner'
+
     schedule:
-      interval: 'monthly'
-  - package-ecosystem: 'npm'
-    directory: '/'
+      interval: monthly
+
+    versioning-strategy: increase
+
+  # Update GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+
     schedule:
       interval: 'monthly'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### :wrench: **Maintenance**
+
 - Upgrade NHS frontend from 10.0 to 10.1
 
 ## 7.1.0 - 20 October 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### :wrench: **Maintenance**
 
 - Upgrade NHS frontend from 10.0 to 10.1
+- Add Dependabot groups with monthly checks
 
 ## 7.1.0 - 20 October 2025
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "lodash": "^4.17.21",
         "nhsuk-frontend": "^10.1.0",
         "nunjucks": "^3.2.4",
-        "path": "^0.12.7",
         "plugin-error": "^2.0.1",
         "portscanner": "^2.2.0",
         "sass-embedded": "1.77.5"
@@ -12637,15 +12636,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
-      "dependencies": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "node_modules/path-dirname": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
@@ -12941,14 +12931,6 @@
       "integrity": "sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -15856,23 +15838,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "dependencies": {
-        "inherits": "2.0.3"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "node_modules/util/node_modules/inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "lodash": "^4.17.21",
     "nhsuk-frontend": "^10.1.0",
     "nunjucks": "^3.2.4",
-    "path": "^0.12.7",
     "plugin-error": "^2.0.1",
     "portscanner": "^2.2.0",
     "sass-embedded": "1.77.5"


### PR DESCRIPTION
## Description

This PR adds Dependabot groups to reduce package update noise

I've removed the Sass update restriction so we can use `@dependabot` comments to ignore updates instead. We might accidentally miss important (or incompatible) changes without it

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [x] CHANGELOG entry
