### PR TITLE
[SPIKE] Add NHS.UK frontend code autocomplete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ pids
 *.launch
 .settings/
 *.sublime-workspace
+*.tsbuildinfo
 
 # IDE - VSCode
 .vscode/*

--- a/app.js
+++ b/app.js
@@ -245,7 +245,11 @@ app.use((req, res, next) => {
 })
 
 // Display error
-app.use((err, req, res) => {
+app.use((err, req, res, next) => {
+  if (res.headersSent) {
+    return next(err)
+  }
+
   console.error(err.message)
   res.status(err.status || 500)
   res.send(err.message)

--- a/app/assets/javascript/main.js
+++ b/app/assets/javascript/main.js
@@ -1,1 +1,3 @@
-// ES6 or Vanilla JavaScript
+import { initAll } from '/nhsuk-frontend/nhsuk-frontend.min.js'
+
+initAll()

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -1,6 +1,6 @@
-<script src="/js/main.js"></script>
+<script type="module" src="/js/main.js"></script>
 {% if useAutoStoreData %}
-  <script src="/js/auto-store-data.js"></script>
+  <script type="module" src="/js/auto-store-data.js"></script>
 {% endif %}
 
 <!-- Add any custom scripts -->

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -47,11 +47,6 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script type="module" src="/nhsuk-frontend/nhsuk-frontend.min.js"></script>
-  <script type="module">
-    import { initAll } from '/nhsuk-frontend/nhsuk-frontend.min.js'
-    initAll()
-  </script>
   {% block scripts %}
     <!-- Custom JavaScript files can be added to this file -->
     {% include "includes/scripts.html" %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -47,7 +47,7 @@
 {% endblock %}
 
 {% block bodyEnd %}
-  <script src="/nhsuk-frontend/nhsuk-frontend.min.js" type="module"></script>
+  <script type="module" src="/nhsuk-frontend/nhsuk-frontend.min.js"></script>
   <script type="module">
     import { initAll } from '/nhsuk-frontend/nhsuk-frontend.min.js'
     initAll()

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,15 @@
         "sass-embedded": "1.77.5"
       },
       "devDependencies": {
+        "@types/body-parser": "^1.19.6",
+        "@types/client-sessions": "^0.8.7",
+        "@types/cookie-parser": "^1.4.10",
+        "@types/express": "^5.0.5",
+        "@types/express-session": "^1.18.2",
+        "@types/jest": "^30.0.0",
+        "@types/lodash": "^4.17.20",
+        "@types/nunjucks": "^3.2.6",
+        "@types/portscanner": "^2.1.4",
         "@typescript-eslint/eslint-plugin": "^8.46.1",
         "@typescript-eslint/parser": "^8.43.0",
         "eslint": "^8.57.1",
@@ -50,6 +59,7 @@
         "eslint-plugin-promise": "^6.6.0",
         "jest": "^30.1.3",
         "prettier": "^3.6.2",
+        "typed-query-selector": "^2.12.0",
         "typescript": "^5.9.3"
       },
       "engines": {
@@ -3160,10 +3170,65 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/client-sessions": {
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/@types/client-sessions/-/client-sessions-0.8.7.tgz",
+      "integrity": "sha512-xOWqQQ8Szcncs2N9Pp+MOu5TblAVdlTzqWu84XB8pPs4wDjwloSYI4lPpo2XH1xHVMEMEghzNDBxfIMCtg0Xsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookies": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
       "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.10.tgz",
+      "integrity": "sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/cookies": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@types/cookies/-/cookies-0.9.2.tgz",
+      "integrity": "sha512-1AvkDdZM2dbyFybL4fxpuNCaWyv//0AwsuUk2DWeXyM1/5ZKm6W3z6mQi24RZ4l2ucY+bkSHzbDVpySqPGuV8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/express": "*",
+        "@types/keygrip": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/cors": {
       "version": "2.8.17",
@@ -3177,6 +3242,48 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.5.tgz",
+      "integrity": "sha512-LuIQOcb6UmnF7C1PCFmEU1u2hmiHL43fgFQX67sN3H4Z+0Yk0Neo++mFsBjhOAuLzvlQeqAAkeDOZrJs9rzumQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
+      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/express-session": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@types/express-session/-/express-session-1.18.2.tgz",
+      "integrity": "sha512-k+I0BxwVXsnEU2hV77cCobC08kIsn4y44C3gC0b46uxZVMaXA04lSPgRLR/bSL2w0t0ShJiG8o4jPzRG/nscFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3216,16 +3323,109 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/keygrip": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/keygrip/-/keygrip-1.0.6.tgz",
+      "integrity": "sha512-lZuNAY9xeJt7Bx4t4dx0rYCDqGPW8RXhQZK1td7d4H6E9zYbLoOtjBvfwdTKpsyxQI/2jv+armjX/RW+ZNpXOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "18.7.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.15.tgz",
       "integrity": "sha512-XnjpaI8Bgc3eBag2Aw4t2Uj/49lLBSStHWfqKvIuXD7FIrZyMLWp8KuAFHAqxMZYTF9l08N1ctUn9YNybZJVmQ=="
+    },
+    "node_modules/@types/nunjucks": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@types/nunjucks/-/nunjucks-3.2.6.tgz",
+      "integrity": "sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/portscanner": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/portscanner/-/portscanner-2.1.4.tgz",
+      "integrity": "sha512-AtwMmUj76lRJ1sXqCU5TGUPeWsA+1nbyltWteRmMz1zLMMTlSE+AEm6M93XeiSxV/qwadFd3uBGQj4f+1b6fvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -15529,6 +15729,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
+      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/typedarray": {
       "version": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,8 @@
         "eslint-plugin-n": "^16.6.2",
         "eslint-plugin-promise": "^6.6.0",
         "jest": "^30.1.3",
-        "prettier": "^3.6.2"
+        "prettier": "^3.6.2",
+        "typescript": "^5.9.3"
       },
       "engines": {
         "node": "^20.9.0 || ^22.11.0"
@@ -15535,12 +15536,11 @@
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,15 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.46.1",
     "@typescript-eslint/parser": "^8.43.0",
+    "@types/body-parser": "^1.19.6",
+    "@types/client-sessions": "^0.8.7",
+    "@types/cookie-parser": "^1.4.10",
+    "@types/express": "^5.0.5",
+    "@types/express-session": "^1.18.2",
+    "@types/jest": "^30.0.0",
+    "@types/lodash": "^4.17.20",
+    "@types/nunjucks": "^3.2.6",
+    "@types/portscanner": "^2.1.4",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^10.1.8",
     "eslint-config-standard": "^17.1.0",
@@ -62,6 +71,7 @@
     "eslint-plugin-promise": "^6.6.0",
     "jest": "^30.1.3",
     "prettier": "^3.6.2",
+    "typed-query-selector": "^2.12.0",
     "typescript": "^5.9.3"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "test:ci": "jest --ci",
     "prewatch": "gulp build",
     "watch": "gulp",
-    "lint": "npm run lint:js && npm run lint:prettier",
+    "lint": "npm run lint:types && npm run lint:js && npm run lint:prettier",
     "lint:fix": "npm run lint:js:fix && npm run lint:prettier:fix",
     "lint:prettier": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check .",
     "lint:prettier:fix": "prettier --write .",
     "lint:js": "eslint --cache --cache-location .cache/eslint --cache-strategy content --color --ignore-path .gitignore \"**/*.js\"",
-    "lint:js:fix": "npm run lint:js -- --fix"
+    "lint:js:fix": "npm run lint:js -- --fix",
+    "lint:types": "tsc --build tsconfig.json --pretty"
   },
   "author": "https://github.com/nhsuk/",
   "license": "MIT",
@@ -60,7 +61,8 @@
     "eslint-plugin-n": "^16.6.2",
     "eslint-plugin-promise": "^6.6.0",
     "jest": "^30.1.3",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "typescript": "^5.9.3"
   },
   "engines": {
     "node": "^20.9.0 || ^22.11.0"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "target": "ESNext",
+    "types": []
+  },
+  "exclude": ["./node_modules", "./public"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,9 @@
     "module": "ESNext",
     "moduleResolution": "Node",
     "noEmit": true,
+    "paths": {
+      "/nhsuk-frontend/nhsuk-frontend.min.js": ["./node_modules/nhsuk-frontend"]
+    },
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "target": "ESNext",

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "checkJs": true,
+    "lib": ["ESNext", "DOM"],
+    "target": "ES2015",
+    "types": ["node"]
+  },
+  "include": ["./app/assets/**/*.js"],
+  "exclude": ["**/*.test.js"]
+}

--- a/tsconfig.client.json
+++ b/tsconfig.client.json
@@ -4,7 +4,7 @@
     "checkJs": true,
     "lib": ["ESNext", "DOM"],
     "target": "ES2015",
-    "types": ["node"]
+    "types": ["node", "typed-query-selector"]
   },
   "include": ["./app/assets/**/*.js"],
   "exclude": ["**/*.test.js"]

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "./*.config.js",
+    "./*.config.mjs",
+    "./.prettierrc.js",
+    "./gulpfile.js",
+    "./tests/**/*.test.js",
+    "./typings/**/*.d.ts"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.base.json",
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.dev.json"
+    },
+    {
+      "path": "./tsconfig.server.json"
+    },
+    {
+      "path": "./tsconfig.client.json"
+    }
+  ]
+}

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "checkJs": true
+  },
+  "include": [
+    "./app.js",
+    "./app/**/*.js",
+    "./lib/**/*.js",
+    "./typings/**/*.d.ts"
+  ],
+  "exclude": ["./app/assets", "**/*.test.js"]
+}


### PR DESCRIPTION
## Description

This PR adds the TypeScript compiler to automatically discover code autocomplete suggestions etc

Seems a shame not to use the published type declarations from NHS.UK frontend package

E.g. Moving the `initAll()` import from HTML to the **main.js** file

<img width="623" height="280" alt="Code autocomplete" src="https://github.com/user-attachments/assets/9f52b2f3-42d6-4997-82eb-932e1bc0154c" />

## Checklist

- [ ] Tested against our [testing policy](https://github.com/nhsuk/nhsuk-frontend/blob/master/docs/contributing/testing.md) (Resolution, Browser & Accessibility)
- [ ] CHANGELOG entry
