### PR TITLE
Remove asset_path from locals

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,6 @@ const useCookieSessionStore =
   process.env.USE_COOKIE_SESSION_STORE || config.useCookieSessionStore
 
 // Add variables that are available in all views
-app.locals.asset_path = '/public/'
 app.locals.useAutoStoreData = useAutoStoreData === 'true'
 app.locals.useCookieSessionStore = useCookieSessionStore === 'true'
 app.locals.serviceName = config.serviceName


### PR DESCRIPTION
I'm pretty sure this isn't used anywhere...

Prototype runs fine without it, and I can’t see any reference to this local variable anywhere.

It was added in #50 but I can’t see any usage of it there either.