### PR TITLE
Remove link in footer to example templates

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -34,10 +34,6 @@
           text: "Home"
         },
         {
-          href: "/example-templates",
-          text: "Page templates"
-        },
-        {
           href: "/prototype-admin/reset?returnPage=" + (currentPage | urlencode),
           text: "Reset data"
         }


### PR DESCRIPTION
The example templates were removed from the kit a while ago, and can now be found at https://prototype-kit.service-manual.nhs.uk/page-templates/ instead.

Thanks to @aviangel-NHS for spotting and reporting!