### PR TITLE
Remove sass-embedded from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,3 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    ignore:
-      # SASS updates will be done manually in sync with
-      # NHS Frontend to avoid deprecation warnings.
-      - dependency-name: 'sass-embedded'


### PR DESCRIPTION
This no longer needs to be specified as it's not a direct dependency any more, but is a sub-dependency of `nhsuk-prototype-kit`