### PR TITLE
Change default port

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -5,5 +5,5 @@ module.exports = {
   serviceName: 'Service name goes here',
 
   // Port to run the prototype on locally
-  port: 2000
+  port: 3000
 }


### PR DESCRIPTION
Change from 2000 to 3000, as we’ve now fixed a bug which means this port is used for the browser-sync process.