### PR TITLE
Fix Codespaces port

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "name": "Service name goes here",
-  // codespaces seems to have an issue using port 2000 so setting to 2001 for the NHS Prototype Kit
-  "runArgs": ["--env", "PORT=2001"],
+  "runArgs": ["--env", "PORT=3001"],
   "portsAttributes": {
     "3001": {
       "label": "Running prototype",


### PR DESCRIPTION
The PORT env is now used as the port by browser-sync (since https://github.com/nhsuk/nhsuk-prototype-kit-package/issues/199), rather than 1000 being added to it.

This updated the Codespaces config so that it now works again.