### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 This repo is used as a template for creating new prototypes using the NHS Prototype kit.
 
 You can edit this README file to add any useful details about running your prototype.
+
+## Running the prototype
+
+1. Install dependencies: `npm install`
+2. Start the prototype: `npm start`
+3. Open http://localhost:3000 in your browser
+
+## Using Visual Studio Code
+
+When you open this project in VS Code, you may see a message: *"Folder contains a Dev Container configuration file. Reopen folder to develop in a container"*.
+
+**You can ignore this message.** You do not need Docker or to reopen in a container to run the prototype locally. Just use the steps above.
+
+The Dev Container is optional as it is used for [GitHub Codespaces](https://github.com/features/codespaces) (cloud development). If you want to develop in a container on your own machine, you would need Docker installed, but that is not required for normal use.

--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ When you open this project in VS Code, you may see a message: *"Folder contains 
 
 **You can ignore this message.** You do not need Docker or to reopen in a container to run the prototype locally. Just use the steps above.
 
-The Dev Container is optional as it is used for [GitHub Codespaces](https://github.com/features/codespaces) (cloud development). If you want to develop in a container on your own machine, you would need Docker installed, but that is not required for normal use.
+The Dev Container is optional as it is used for [GitHub Codespaces](https://github.com/features/codespaces) (cloud development). If you want to develop in a container on your own machine you would need Docker installed, but that is not required for normal use.


### PR DESCRIPTION
# Add documentation to clarify VS Code Dev Container prompt (fixes #443)

## Summary

When users open the prototype kit in Visual Studio Code, they see a message: *"Folder contains a Dev Container configuration file. Reopen folder to develop in a container"*. This causes confusion, users don't know whether they need to install Docker or if they should ignore the prompt.

This PR adds documentation to clarify that the prompt can be ignored and that Docker is not required for normal local development, pending the time a solution is found for it.

## Changes

### README.md
