### PR TITLE
Fix typo on res.locals comment example

### DIFF
--- a/app/locals.js
+++ b/app/locals.js
@@ -5,7 +5,7 @@ module.exports = function(req, res, next) {
   //
   // For example:
   //
-  // req.locals.organisationName = 'NHS'
+  // res.locals.organisationName = 'NHS'
 
   next()
 }


### PR DESCRIPTION
Tiny little typo to change `req.locals` → `res.locals` in the comment example