### PR TITLE
Add kit and frontend version numbers in footer

### DIFF
--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -26,6 +26,10 @@
 <!-- Edit the footer -->
 <!-- Footer code examples can be found at https://service-manual.nhs.uk/design-system/components/footer -->
 {% block footer %}
+  {% set metaAboutHtml %}
+    <p class="nhsuk-body-s">Built on <a href="https://prototype-kit.service-manual.nhs.uk/updates/"  class="nhsuk-footer__list-item-link">NHS prototype kit {{ prototypeKitVersion }}</a> and <a href="https://github.com/nhsuk/nhsuk-frontend/releases/"  class="nhsuk-footer__list-item-link">NHS.UK frontend {{ nhsukFrontendVersion }}</a></p>
+  {% endset %}
+
   {{ footer({
     meta: {
       items: [
@@ -38,7 +42,7 @@
           text: "Reset data"
         }
       ],
-      html: '<p class="nhsuk-body-s">Built on <a href="https://prototype-kit.service-manual.nhs.uk/updates/">NHS prototype kit ' + prototypeKitVersion + '</a> and <a href="">NHS.UK frontend ' + nhsukFrontendVersion + '</a></p>'
+      html: metaAboutHtml
     }
   }) }}
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -37,7 +37,8 @@
           href: "/prototype-admin/reset?returnPage=" + (currentPage | urlencode),
           text: "Reset data"
         }
-      ]
+      ],
+      html: '<p class="nhsuk-body-s">Built on <a href="https://prototype-kit.service-manual.nhs.uk/updates/">NHS prototype kit ' + prototypeKitVersion + '</a> and <a href="">NHS.UK frontend ' + nhsukFrontendVersion + '</a></p>'
     }
   }) }}
 {% endblock %}

--- a/app/views/layout.html
+++ b/app/views/layout.html
@@ -27,7 +27,7 @@
 <!-- Footer code examples can be found at https://service-manual.nhs.uk/design-system/components/footer -->
 {% block footer %}
   {% set metaAboutHtml %}
-    <p class="nhsuk-body-s">Built on <a href="https://prototype-kit.service-manual.nhs.uk/updates/"  class="nhsuk-footer__list-item-link">NHS prototype kit {{ prototypeKitVersion }}</a> and <a href="https://github.com/nhsuk/nhsuk-frontend/releases/"  class="nhsuk-footer__list-item-link">NHS.UK frontend {{ nhsukFrontendVersion }}</a></p>
+    <p class="nhsuk-body-s">Built on <a class="nhsuk-footer__list-item-link" href="https://prototype-kit.service-manual.nhs.uk/updates/">NHS prototype kit {{ prototypeKitVersion }}</a> and <a class="nhsuk-footer__list-item-link" href="https://github.com/nhsuk/nhsuk-frontend/releases/">NHS.UK frontend {{ nhsukFrontendVersion }}</a></p>
   {% endset %}
 
   {{ footer({


### PR DESCRIPTION
This adds the version number of NHS prototype kit and NHS frontend into the default footer.

<img width="1005" height="829" alt="Screenshot 2026-03-23 at 13 14 11" src="https://github.com/user-attachments/assets/ccbfeb07-366f-4395-8c89-50d7d59f429d" />

Resolves https://github.com/nhsuk/nhsuk-prototype-kit-package/issues/239

This is just the default footer in this template repository, so users can change it if needed.

