### PR TITLE
Add cooldown configuration for template repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 7
+      exclude:
+        - 'nhsuk-frontend'
+        - 'nhsuk-prototype-kit'


### PR DESCRIPTION
This helps prevent supply chain attacks.

The `nhsuk-frontend` and `nhsuk-prototype-kit` packages are excluded, as those themselves have cooldowns configured, and so we don't want to double-up.